### PR TITLE
Update to pipe-tools v0.1.5

### DIFF
--- a/airflow/pipe_segment_dag.py
+++ b/airflow/pipe_segment_dag.py
@@ -56,7 +56,6 @@ def build_dag(dag_id, schedule_interval='@daily', extra_default_args=None, extra
 
         segment = DataFlowDirectRunnerOperator(
             task_id='segment',
-            pool='dataflow',
             depends_on_past=True,
             py_file=Variable.get('DATAFLOW_WRAPPER_STUB'),
             priority_weight=10,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-https://codeload.github.com/GlobalFishingWatch/pipe-tools/tar.gz/v0.1.4#egg=pipe-tools-0.1.4
-https://codeload.github.com/Skytruth/gpsdio-segment/tar.gz/d718437531c1de328456ac64f1bfd11cffafc351#egg=gpsdio-segment-0.10
+https://codeload.github.com/GlobalFishingWatch/pipe-tools/tar.gz/v0.1.5#egg=pipe-tools-0.1.5
+https://codeload.github.com/Skytruth/gpsdio-segment/tar.gz/v0.11#egg=gpsdio-segment-0.11
 https://codeload.github.com/GlobalFishingWatch/ShipDataProcess/tar.gz/70f52826074b8b65a2811ea3ae626a9373cdb83d#egg=shipdataprocess-0.5.0

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ DEPENDENCIES = [
     "udatetime",
     "newlinejson",
     "python-stdnum",
-    "pipe-tools==0.1.4",
-    "gpsdio-segment==0.10",
+    "pipe-tools==0.1.5",
+    "gpsdio-segment==0.11",
     "shipdataprocess==0.5.0",
     "jinja2-cli",
 ]


### PR DESCRIPTION
Update to pipe-tools v0.1.5
Update to gpsdio-segment v0.11 (no change, just use the version tag instead of pinning to a commit hash)
Remove explicit setting of `pool` in the segment task in airflow - instead let pipe-tools set the pool based on the dataflowRunner