### PR TITLE
Parameterize max_num_workers

### DIFF
--- a/airflow/pipe_segment_dag.py
+++ b/airflow/pipe_segment_dag.py
@@ -71,7 +71,7 @@ def build_dag(dag_id, schedule_interval='@daily', extra_default_args=None, extra
                 runner='{dataflow_runner}'.format(**config),
                 project=config['project_id'],
                 disk_size_gb="50",
-                max_num_workers="100",
+                max_num_workers="{max_num_workers}".format(**config),
                 worker_machine_type='custom-1-15360-ext',
                 temp_location='gs://{temp_bucket}/dataflow_temp'.format(**config),
                 staging_location='gs://{temp_bucket}/dataflow_staging'.format(**config),

--- a/airflow/post_install.sh
+++ b/airflow/post_install.sh
@@ -10,6 +10,7 @@ python $AIRFLOW_HOME/utils/set_default_variables.py \
     docker_run="{{ var.value.DOCKER_RUN }}" \
     identity_messages_monthly_table="identity_messages_monthly_" \
     messages_table="messages_segmented_" \
+    max_num_workers="100" \
     normalized_tables="normalized_orbcomm_,normalized_spire_" \
     pipeline_bucket="{{ var.value.PIPELINE_BUCKET }}" \
     pipeline_dataset="{{ var.value.PIPELINE_DATASET }}" \


### PR DESCRIPTION
Close #58 

 Expose max_num_workers in airflow variables so the value can be changed at runtime from the airflow dashboard

### Testing
This was released in a hotfix to production and used to backfill in pipe_production_b.   seems to work...