### PR TITLE
Include noise flag and message count in segment_info

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,11 @@ Changes
 
 Higher level changes affecting the API or data.
 
+DEV
+--- 
+* [#61](https://github.com/GlobalFishingWatch/pipe-segment/pull/61)
+  Include additional noise and message count fields in segment_info table 
+  
 0.2.2 - 2018-07-06
 ------------------
  

--- a/assets/segment_info.schema.json
+++ b/assets/segment_info.schema.json
@@ -1,0 +1,51 @@
+[
+    {
+      "mode": "NULLABLE",
+      "name": "seg_id",
+      "type": "STRING",
+      "description": "unique segment id.  This table has one row per segment id"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "ssvid",
+      "type": "STRING",
+      "description": "source specific vessel id.  This is the transponder id, and for AIS this is the MMSI"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "vessel_id",
+      "type": "STRING",
+      "description": "unique vessel id assigned by the pipeline.  There may be more than one vessel_id per ssvid"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "msg_count",
+      "type": "INTEGER",
+      "description": "Total number of messages in the segment, including identiy messages and positional messages"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "pos_count",
+      "type": "INTEGER",
+      "description": "Total number or positional messages in the segment.   Consider filtering out messages in segments with only a small number of positional messagess"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "first_timestamp",
+      "type": "TIMESTAMP",
+      "description": "Timestamp of the first message in the segment"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "last_timestamp",
+      "type": "TIMESTAMP",
+      "description": "Timestamp of the last message in the segment"
+    },
+    {
+      "mode": "NULLABLE",
+      "name": "noise",
+      "type": "BOOLEAN",
+      "description": "If true, then this is a noise segment, usually because of an invalid lat or lon value.  Messages in these segments should be filtered out"
+    }
+]
+

--- a/assets/segment_info.sql.j2
+++ b/assets/segment_info.sql.j2
@@ -2,7 +2,12 @@
 SELECT
  seg_id,
  ssvid,
- vessel_id
+ vessel_id,
+ SUM(msg_count) as msg_count,
+ SUM(pos_count) as pos_count,
+ MIN(first_timestamp) as first_timestamp,
+ MIN(last_timestamp) as last_timestamp,
+ LOGICAL_OR(noise) as noise
 FROM `{{ segment_identity }}*`
 GROUP BY
   vessel_id,

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,6 @@ services:
   pipe_segment:
     image: gfw/pipe-segment
     build: .
-    entrypoint: python -m pipe_segment
     volumes:
       - ".:/opt/project"
       - "gcp:/root/.config/"

--- a/pipe_segment/__init__.py
+++ b/pipe_segment/__init__.py
@@ -3,7 +3,7 @@ Tools for parsing and normalizing AIS from Orbcomm using dataflow
 """
 
 
-__version__ = '0.2.2'
+__version__ = '0.2.3-dev'
 __author__ = 'Paul Woods'
 __email__ = 'paul@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/pipe-segment'

--- a/scripts/segment_info.sh
+++ b/scripts/segment_info.sh
@@ -22,7 +22,7 @@ fi
 SEGMENT_IDENTITY_TABLE=$1
 DEST_TABLE=$2
 
-
+SCHEMA=${ASSETS}/segment_info.schema.json
 SQL=${ASSETS}/segment_info.sql.j2
 TABLE_DESC=(
   "* Pipeline: ${PIPELINE} ${PIPELINE_VERSION}"
@@ -30,6 +30,7 @@ TABLE_DESC=(
   "* Command:"
   "$(basename $0)"
   "$@"
+  "Summary table for segments.  One row per segement id. This table can be used to filter out noise segments and to map between ssvid and vesssel_id "
 )
 TABLE_DESC=$( IFS=$'\n'; echo "${TABLE_DESC[*]}" )
 
@@ -40,6 +41,8 @@ jinja2 ${SQL} \
    -D segment_identity=${SEGMENT_IDENTITY_TABLE//:/.} \
    | bq query --max_rows=0 --allow_large_results --replace \
      --destination_table ${DEST_TABLE}
+
+bq update --schema ${SCHEMA} --description "${TABLE_DESC}" ${DEST_TABLE}
 
 echo "  ${DEST} Done."
 


### PR DESCRIPTION
Close #60

Adds summary fields to the segment_info table.  One use case for this is filtering out short/noise segments based on pos_count

* msg_count,
* pos_count,
* first_timestamp,
* last_timestamp,
* noise

Tested with 
```console
docker-compose run pipe_segment segment_info pipe_production_b.segment_identity_ world-fishing-827:scratch_paul_ttl_100.segment_info_test_b
```
and then inspecting the output