### PR TITLE
Refactor Segment Identity

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@ Changes
 
 Higher level changes affecting the API or data.
 
-0.2.4-dev
+0.2.4 - 
 ---------
 * [#66](https://github.com/GlobalFishingWatch/pipe-segment/pull/66)
   Refactor Segment Identity

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@ DEV
 --- 
 * [#61](https://github.com/GlobalFishingWatch/pipe-segment/pull/61)
   Include additional noise and message count fields in segment_info table 
+* [#66](https://github.com/GlobalFishingWatch/pipe-segment/pull/66)
+  Refactor Segment Identity
   
 0.2.2 - 2018-07-06
 ------------------

--- a/airflow/post_install.sh
+++ b/airflow/post_install.sh
@@ -16,10 +16,17 @@ python $AIRFLOW_HOME/utils/set_default_variables.py \
     pipeline_dataset="{{ var.value.PIPELINE_DATASET }}" \
     project_id="{{ var.value.PROJECT_ID }}" \
     segment_identity_table="segment_identity_" \
-    segments_table="segments_" \
+    segment_identity_daily_table="segment_identity_daily_" \
     segment_info_table="segment_info" \
+    segment_vessel_daily_table="segment_vessel_daily_" \
+    segment_vessel_table="segment_vessel" \
+    segments_table="segments_" \
+    single_ident_min_freq="0.99" \
     source_dataset="{{ var.value.PIPELINE_DATASET }}" \
+    vessel_info_table="vessel_info" \
     temp_bucket="{{ var.value.TEMP_BUCKET }}"  \
+    window_days="30"  \
+
 
 echo "Installation Complete"
 

--- a/assets/segment_identity_daily.schema.json
+++ b/assets/segment_identity_daily.schema.json
@@ -1,0 +1,185 @@
+[
+  {
+    "mode": "NULLABLE",
+    "name": "seg_id",
+    "type": "STRING",
+    "description": "unique segment id.  This table has one row per segment id per day"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "ssvid",
+    "type": "STRING",
+    "description": "source specific vessel id.  This is the transponder id, and for AIS this is the MMSI"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "first_timestamp",
+    "type": "TIMESTAMP",
+    "description": "Timestamp of the first message in the segment for this day"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "last_timestamp",
+    "type": "TIMESTAMP",
+    "description": "Timestamp of the last message in the segment for this day"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "msg_count",
+    "type": "INTEGER",
+    "description": "Total number of messages (positional and identity messages) in the segment for this day"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "pos_count",
+    "type": "INTEGER",
+    "description": "Number of positional messages in the segment for this day"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "noise",
+    "type": "BOOLEAN",
+    "description": "If true, then this is a noise segment, usually because of an invalid lat or lon value.  Messages in these segments should be filtered out"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "Unique field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the unique field value occured for this segment for this day"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "shipname",
+    "type": "RECORD",
+    "description": "Array of all unique shipnames (unnormalized) for this segment for this day."
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "Unique field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the unique field value occured for this segment for this day"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "callsign",
+    "type": "RECORD",
+    "description": "Array of all unique callsigns (unnormalized) for this segment for this day."
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "Unique field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the unique field value occured for this segment for this day"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "imo",
+    "type": "RECORD",
+    "description": "Array of all unique imo numbers (unvalidated) for this segment for this day."
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "Unique field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the unique field value occured for this segment for this day"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "n_shipname",
+    "type": "RECORD",
+    "description": "Array of all unique normalized shipnames for this segment for this day."
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "Unique field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the unique field value occured for this segment for this day"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "n_callsign",
+    "type": "RECORD",
+    "description": "Array of all unique normalized callsigns for this segment for this day."
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "Unique field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the unique field value occured for this segment for this day"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "n_imo",
+    "type": "RECORD",
+    "description": "Array of all unique valid imo numbers for this segment for this day."
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "Unique field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the unique field value occured for this segment for this day"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "shiptype",
+    "type": "RECORD",
+    "description": "Array of all unique shiptypes for this segment for this day. Note that this field is already normalized in the messages"
+  }
+]
+

--- a/assets/segment_identity_daily.sql.j2
+++ b/assets/segment_identity_daily.sql.j2
@@ -1,0 +1,144 @@
+#standardSQL
+#
+# Aggregates segment identity field counts from segment_identity_daily across a
+# multi-day window and assigns a vessel_id guid to each segment for the current day
+# which is the last day of the window
+#
+
+WITH
+  #
+  # Get segmented messages, including posititional and identity messages
+  #
+  messages AS (
+  SELECT
+    ssvid,
+    seg_id,
+    timestamp,
+    lat,
+    shipname,
+    callsign,
+    imo,
+    n_shipname,
+    n_callsign,
+    n_imo,
+    shiptype
+  FROM
+    `{{ messages }}`
+  ),
+  #
+  # Get the noise flag that indicates that the segment has bad position data
+  #
+  segment_noise as (
+  SELECT
+    seg_id,
+    LOGICAL_OR(noise) as noise
+  FROM
+    `{{ segments }}`
+  GROUP BY
+    seg_id
+  ),
+  #
+  # Compute overall statistics for each segment, preserve ssvid
+  #
+  segment_summary AS (
+  SELECT
+    ssvid,
+    seg_id,
+    min(timestamp) as first_timestamp,
+    max(timestamp) as last_timestamp,
+    COUNT(*) AS msg_count,
+    COUNTIF(lat IS NOT NULL) AS pos_count
+  FROM
+    messages
+  GROUP BY
+    ssvid,
+    seg_id ),
+  #
+  # Shipname: count of occurences per segment for each non-null value
+  #
+  segment_shipname AS (
+    SELECT seg_id, ARRAY_AGG(STRUCT(value, count)) as shipname FROM (
+      SELECT seg_id, shipname as value, COUNT(*) AS count FROM messages
+      WHERE shipname IS NOT NULL GROUP BY seg_id, value
+      ) GROUP BY seg_id
+    ),
+  #
+  # Callsign: count of occurences per segment for each non-null value
+  #
+  segment_callsign AS (
+    SELECT seg_id, ARRAY_AGG(STRUCT(value, count)) as callsign FROM (
+      SELECT seg_id, callsign as value, COUNT(*) AS count FROM messages
+      WHERE callsign IS NOT NULL GROUP BY seg_id, value
+      ) GROUP BY seg_id
+    ),
+  #
+  # IMO: count of occurences per segment for each non-null value
+  #
+  segment_imo AS (
+    SELECT seg_id, ARRAY_AGG(STRUCT(value, count)) as imo FROM (
+      SELECT seg_id, imo as value, COUNT(*) AS count FROM messages
+      WHERE imo IS NOT NULL GROUP BY seg_id, value
+      ) GROUP BY seg_id
+    ),
+  #
+  # n_shipname: count of occurences per segment for each non-null value
+  #
+  segment_n_shipname AS (
+    SELECT seg_id, ARRAY_AGG(STRUCT(value, count)) as n_shipname FROM (
+      SELECT seg_id, n_shipname as value, COUNT(*) AS count FROM messages
+      WHERE n_shipname IS NOT NULL GROUP BY seg_id, value
+      ) GROUP BY seg_id
+    ),
+  #
+  # n_callsign: count of occurences per segment for each non-null value
+  #
+  segment_n_callsign AS (
+    SELECT seg_id, ARRAY_AGG(STRUCT(value, count)) as n_callsign FROM (
+      SELECT seg_id, n_callsign as value, COUNT(*) AS count FROM messages
+      WHERE n_callsign IS NOT NULL GROUP BY seg_id, value
+      ) GROUP BY seg_id
+    ),
+  #
+  # n_imo: count of occurences per segment for each non-null value
+  #
+  segment_n_imo AS (
+    SELECT seg_id, ARRAY_AGG(STRUCT(value, count)) as n_imo FROM (
+      SELECT seg_id, CAST(n_imo as STRING) as value, COUNT(*) AS count FROM messages
+      WHERE n_imo IS NOT NULL GROUP BY seg_id, value
+      ) GROUP BY seg_id
+    ),
+  #
+  # shiptype: count of occurences per segment for each non-null value
+  #
+  segment_shiptype AS (
+    SELECT seg_id, ARRAY_AGG(STRUCT(value, count)) as shiptype FROM (
+      SELECT seg_id, shiptype as value, COUNT(*) AS count FROM messages
+      WHERE shiptype IS NOT NULL GROUP BY seg_id, value
+      ) GROUP BY seg_id
+    ),
+  #
+  # Stitch all the pieces together for one row per segment
+  #
+  segment_daily as (
+    SELECT
+      *
+    FROM
+      segment_summary
+      LEFT JOIN segment_noise USING (seg_id)
+      LEFT JOIN segment_shipname USING (seg_id)
+      LEFT JOIN segment_callsign USING (seg_id)
+      LEFT JOIN segment_imo USING (seg_id)
+      LEFT JOIN segment_n_shipname USING (seg_id)
+      LEFT JOIN segment_n_callsign USING (seg_id)
+      LEFT JOIN segment_n_imo USING (seg_id)
+      LEFT JOIN segment_shiptype USING (seg_id)
+  )
+
+
+SELECT
+  *
+FROM
+  segment_daily
+
+
+

--- a/assets/segment_info.schema.json
+++ b/assets/segment_info.schema.json
@@ -1,51 +1,228 @@
 [
-    {
-      "mode": "NULLABLE",
-      "name": "seg_id",
-      "type": "STRING",
-      "description": "unique segment id.  This table has one row per segment id"
-    },
-    {
-      "mode": "NULLABLE",
-      "name": "ssvid",
-      "type": "STRING",
-      "description": "source specific vessel id.  This is the transponder id, and for AIS this is the MMSI"
-    },
-    {
-      "mode": "NULLABLE",
-      "name": "vessel_id",
-      "type": "STRING",
-      "description": "unique vessel id assigned by the pipeline.  There may be more than one vessel_id per ssvid"
-    },
-    {
-      "mode": "NULLABLE",
-      "name": "msg_count",
-      "type": "INTEGER",
-      "description": "Total number of messages in the segment, including identiy messages and positional messages"
-    },
-    {
-      "mode": "NULLABLE",
-      "name": "pos_count",
-      "type": "INTEGER",
-      "description": "Total number or positional messages in the segment.   Consider filtering out messages in segments with only a small number of positional messagess"
-    },
-    {
-      "mode": "NULLABLE",
-      "name": "first_timestamp",
-      "type": "TIMESTAMP",
-      "description": "Timestamp of the first message in the segment"
-    },
-    {
-      "mode": "NULLABLE",
-      "name": "last_timestamp",
-      "type": "TIMESTAMP",
-      "description": "Timestamp of the last message in the segment"
-    },
-    {
-      "mode": "NULLABLE",
-      "name": "noise",
-      "type": "BOOLEAN",
-      "description": "If true, then this is a noise segment, usually because of an invalid lat or lon value.  Messages in these segments should be filtered out"
-    }
+  {
+    "mode": "NULLABLE",
+    "name": "seg_id",
+    "type": "STRING",
+    "description": "unique segment id.  This table has one row per segment id"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "ssvid",
+    "type": "STRING",
+    "description": "source specific vessel id.  This is the transponder id, and for AIS this is the MMSI"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "first_timestamp",
+    "type": "TIMESTAMP",
+    "description": "Timestamp of the first message in the segment"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "last_timestamp",
+    "type": "TIMESTAMP",
+    "description": "Timestamp of the last message in the segment"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "msg_count",
+    "type": "INTEGER",
+    "description": "Total number of messages in the segment, including identiy messages and positional messages"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "pos_count",
+    "type": "INTEGER",
+    "description": "Total number or positional messages in the segment.   Consider filtering out messages in segments with only a small number of positional messagess"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "noise",
+    "type": "BOOLEAN",
+    "description": "If true, then this is a noise segment, usually because of an invalid lat or lon value.  Messages in these segments should be filtered out"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the this field value occured for this segment"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "freq",
+        "type": "FLOAT",
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "shipname",
+    "type": "RECORD",
+    "description": "Most commonly occuring shipname (unnormalized) for this segment"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the this field value occured for this segment"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "freq",
+        "type": "FLOAT",
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "callsign",
+    "type": "RECORD",
+    "description": "Most commonly occuring callsign (unnormalized) for this segment"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the this field value occured for this segment"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "freq",
+        "type": "FLOAT",
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "imo",
+    "type": "RECORD",
+    "description": "Most commonly occuring imo number (unvalidated) for this segment"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the this field value occured for this segment"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "freq",
+        "type": "FLOAT",
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "n_shipname",
+    "type": "RECORD",
+    "description": "Most commonly occuring normalized shipname for this segment"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the this field value occured for this segment"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "freq",
+        "type": "FLOAT",
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "n_callsign",
+    "type": "RECORD",
+    "description": "Most commonly occuring normalized callsign for this segment"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the this field value occured for this segment"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "freq",
+        "type": "FLOAT",
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "n_imo",
+    "type": "RECORD",
+    "description": "Most commonly occuring valid imo number for this segment"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the this field value occured for this segment "
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "freq",
+        "type": "FLOAT",
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "shiptype",
+    "type": "RECORD",
+    "description": "Most commonly occuring shiptype for this segment.  Note that shiptype is already normalized in the source messages."
+  }
+
 ]
 

--- a/assets/segment_info.sql.j2
+++ b/assets/segment_info.sql.j2
@@ -1,15 +1,59 @@
 #standardSQL
+#
+# Create a segment info table with one row per seg_id from segment_identity_daily
+# Includes the entire time range from the source table
+#
+# FUNCTIONS
+#
+# Simple map/reduce that finds the most common string value in a list of string,int tuples
+# Finds and returns the string with the highest sum of the associated integer values, and
+# computes the frequency of that value relative to the total of all values in the list
+#
+CREATE TEMP FUNCTION mostCommon(arr ARRAY<STRUCT<value STRING, count INT64>>) AS (
+  (
+   select as struct
+     value,
+     count,
+     count/(select sum(r.count) from unnest(arr) as r ) as freq
+   from (
+     select as struct r.value as value, sum(r.count) as count from unnest(arr) as r group by r.value order by count DESC limit 1
+     )
+   )
+);
+WITH
+  segments as (
+  SELECT
+    *
+  FROM
+    `world-fishing-827.scratch_paul_ttl_100.segment_identity_daily_*`
+  ),
+  #
+  # Aggregate daily segment identity counts over the full time range
+  # and reduce each identity field to just the most commonly occuring value
+  segment_most_common as (
+  SELECT
+    seg_id,
+    ssvid,
+    MIN(first_timestamp) as first_timestamp,
+    MAX(last_timestamp) as last_timestamp,
+    SUM(msg_count) as msg_count,
+    SUM(pos_count) as pos_count,
+    LOGICAL_OR(noise) as noise,
+    mostCommon(ARRAY_CONCAT_AGG(shipname)) as shipname,
+    mostCommon(ARRAY_CONCAT_AGG(callsign)) as callsign,
+    mostCommon(ARRAY_CONCAT_AGG(imo)) as imo,
+    mostCommon(ARRAY_CONCAT_AGG(n_shipname)) as n_shipname,
+    mostCommon(ARRAY_CONCAT_AGG(n_callsign)) as n_callsign,
+    mostCommon(ARRAY_CONCAT_AGG(n_imo)) as n_imo,
+    mostCommon(ARRAY_CONCAT_AGG(shiptype)) as shiptype
+  FROM
+    segments
+  GROUP by
+    ssvid,
+    seg_id
+  )
+
 SELECT
- seg_id,
- ssvid,
- vessel_id,
- SUM(msg_count) as msg_count,
- SUM(pos_count) as pos_count,
- MIN(first_timestamp) as first_timestamp,
- MIN(last_timestamp) as last_timestamp,
- LOGICAL_OR(noise) as noise
-FROM `{{ segment_identity }}*`
-GROUP BY
-  vessel_id,
-  ssvid,
-  seg_id
+  *
+FROM
+  segment_most_common

--- a/assets/segment_info.sql.j2
+++ b/assets/segment_info.sql.j2
@@ -3,29 +3,16 @@
 # Create a segment info table with one row per seg_id from segment_identity_daily
 # Includes the entire time range from the source table
 #
-# FUNCTIONS
-#
-# Simple map/reduce that finds the most common string value in a list of string,int tuples
-# Finds and returns the string with the highest sum of the associated integer values, and
-# computes the frequency of that value relative to the total of all values in the list
-#
-CREATE TEMP FUNCTION mostCommon(arr ARRAY<STRUCT<value STRING, count INT64>>) AS (
-  (
-   select as struct
-     value,
-     count,
-     count/(select sum(r.count) from unnest(arr) as r ) as freq
-   from (
-     select as struct r.value as value, sum(r.count) as count from unnest(arr) as r group by r.value order by count DESC limit 1
-     )
-   )
-);
+
+# Include some utility functions
+{% include 'util.sql.j2' %}
+
 WITH
   segments as (
   SELECT
     *
   FROM
-    `world-fishing-827.scratch_paul_ttl_100.segment_identity_daily_*`
+    `{{ segment_identity_daily }}*`
   ),
   #
   # Aggregate daily segment identity counts over the full time range

--- a/assets/segment_vessel.schema.json
+++ b/assets/segment_vessel.schema.json
@@ -1,0 +1,40 @@
+[
+  {
+    "mode": "NULLABLE",
+    "name": "seg_id",
+    "type": "STRING",
+    "description": "Unique segment  id.  Each seg_id can be associated with many vessel_ids, though usually a small number and most commonly 1. A seg_id is associated with only one ssvid "
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "ssvid",
+    "type": "STRING",
+    "description": "Source specific vessel id.  This is the transponder id, and for AIS this is the MMSI"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "vessel_id",
+    "type": "STRING",
+    "description": "Unique vessel id. Each vessel_id can be associated with many seg_ids, and only one ssvid"
+
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "days",
+    "type": "INTEGER",
+    "description": "Number of days in which this seg_id exists and is mapped to this vessel_id.  Use this to determine the dominant vessel_id for a seg_id. To find out eactly which days, query seg_id, vessel_id and day from segment_vessel_daily_*"
+
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "first_date",
+    "type": "DATE",
+    "description": "Earliest date when this seg_id was associated with this vessel_id"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "last_date",
+    "type": "DATE",
+    "description": "Latest date when this seg_id was associated with this vessel_id"
+  }
+]

--- a/assets/segment_vessel.sql.j2
+++ b/assets/segment_vessel.sql.j2
@@ -1,0 +1,24 @@
+#standardSQL
+#
+# Create a many-to-many table mapping all segment_ids to vessel_ids
+#
+WITH
+  segments as (
+  SELECT
+    seg_id,
+    ssvid,
+    vessel_id
+  FROM
+    `world-fishing-827.scratch_paul_ttl_100.segment_vessel_daily_*`
+  )
+SELECT
+  seg_id,
+  ssvid,
+  vessel_id,
+  count(DISTINCT day) as days
+FROM
+  segments
+GROUP BY
+  seg_id,
+  ssvid,
+  vessel_id

--- a/assets/segment_vessel.sql.j2
+++ b/assets/segment_vessel.sql.j2
@@ -1,21 +1,25 @@
 #standardSQL
 #
-# Create a many-to-many table mapping all segment_ids to vessel_ids
+# Create a many-to-many table mapping between segment_id, vessel_id and ssvid
 #
 WITH
   segments as (
   SELECT
     seg_id,
     ssvid,
-    vessel_id
+    vessel_id,
+    day
   FROM
-    `world-fishing-827.scratch_paul_ttl_100.segment_vessel_daily_*`
+    `{{ segment_vessel_daily }}*`
   )
+
 SELECT
   seg_id,
   ssvid,
   vessel_id,
-  count(DISTINCT day) as days
+  count(DISTINCT day) as days,
+  min(day) as first_date,
+  max(day) as last_date
 FROM
   segments
 GROUP BY

--- a/assets/segment_vessel_daily.schema.json
+++ b/assets/segment_vessel_daily.schema.json
@@ -1,0 +1,245 @@
+[
+  {
+    "mode": "NULLABLE",
+    "name": "vessel_id",
+    "type": "STRING",
+    "description": "vessel_id assigned to this segment for the current day.  The vessel_id is a hash of ssvid, n_imo, n_shipname and n_callsign, where n_imo, n_shipname and n_callsign are the most commonly occuring values within the segment or within the ssvid, depending on the value of single_ident_ssvid"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "single_ident_ssvid",
+    "type": "BOOLEAN",
+    "description": "If true, then ssvid for this segment was found to have a single dominant identity over WINDOW_DAYS, so the aggregate identity of all segments in this ssvid is used to produce vessel_id."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "seg_id",
+    "type": "STRING",
+    "description": "Unique segment id.  This table has one row per segment id per day"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "ssvid",
+    "type": "STRING",
+    "description": "Source specific vessel id.  This is the transponder id, and for AIS this is the MMSI"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "day",
+    "type": "DATE",
+    "description": "The date when the vessel_id was associated with this seg_id.  This is the same as the table date shard.  A seg_id can be associated with more than one vessel_id, but it will only have a single vessel_id for any given day."
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "first_timestamp",
+    "type": "TIMESTAMP",
+    "description": "Timestamp of the first message in the segment for this day"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "last_timestamp",
+    "type": "TIMESTAMP",
+    "description": "Timestamp of the last message in the segment for this day"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "msg_count",
+    "type": "INTEGER",
+    "description": "Total number of messages (positional and identity messages) in the segment over WINDOW_DAYS"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "pos_count",
+    "type": "INTEGER",
+    "description": "Number of positional messages in the segment over WINDOW_DAYS"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "noise",
+    "type": "BOOLEAN",
+    "description": "If true, then this is a noise segment, usually because of an invalid lat or lon value.  Messages in these segments should be filtered out"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the this field value occured for this segment for this day"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "freq",
+        "type": "FLOAT",
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "shipname",
+    "type": "RECORD",
+    "description": "Most commonly occuring shipname (unnormalized) for this segment over WINDOW_DAYS"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the this field value occured for this segment for this day"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "freq",
+        "type": "FLOAT",
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "callsign",
+    "type": "RECORD",
+    "description": "Most commonly occuring callsign (unnormalized) for this segment over WINDOW_DAYS"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the this field value occured for this segment for this day"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "freq",
+        "type": "FLOAT",
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "imo",
+    "type": "RECORD",
+    "description": "Most commonly occuring imo number (unvalidated) for this segment over WINDOW_DAYS"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the this field value occured for this segment for this day"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "freq",
+        "type": "FLOAT",
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "n_shipname",
+    "type": "RECORD",
+    "description": "Most commonly occuring normalized shipname for this segment over WINDOW_DAYS"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the this field value occured for this segment for this day"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "freq",
+        "type": "FLOAT",
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "n_callsign",
+    "type": "RECORD",
+    "description": "Most commonly occuring normalized callsign for this segment over WINDOW_DAYS"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the this field value occured for this segment for this day"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "freq",
+        "type": "FLOAT",
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "n_imo",
+    "type": "RECORD",
+    "description": "Most commonly occuring valid imo number for this segment over WINDOW_DAYS"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the this field value occured for this segment for this day"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "freq",
+        "type": "FLOAT",
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "shiptype",
+    "type": "RECORD",
+    "description": "Most commonly occuring shiptype for this segment over WINDOW_DAYS.  Note that shiptype is already normalized in the source messages."
+  }
+]
+

--- a/assets/segment_vessel_daily.sql.j2
+++ b/assets/segment_vessel_daily.sql.j2
@@ -1,0 +1,161 @@
+#standardSQL
+#
+# Aggregates segment identity field counts from segment_identity_daily across a
+# multi-day window and assigns a vessel_id guid to each segment for the current day
+# which is the last day of the window
+#
+#
+# PARAMETERS
+#
+CREATE TEMP FUNCTION processDate() AS (DATE('{{ date }}'));
+CREATE TEMP FUNCTION windowDays() AS ({{ window_days }});
+CREATE TEMP FUNCTION windowStart() AS (DATE_SUB(processDate(), INTERVAL (windowDays() - 1) DAY));
+CREATE TEMP FUNCTION singleIdentMinFreq() AS ({{ single_ident_min_freq }});
+
+# Include some utility functions
+{% include 'util.sql.j2' %}
+
+#
+# Building the query
+#
+WITH
+  #
+  # Daily segment identity counts over a multi-day time window
+  #
+  segments as (
+  SELECT
+    *
+  FROM
+    `{{ segment_identity_daily }}*`
+  WHERE
+    _TABLE_SUFFIX between YYYYMMDD(windowStart()) AND YYYYMMDD(processDate())
+  ),
+
+  #
+  # Aggregate daily segment identity counts over a multi-day time window
+  # and reduce each identity field to just the most commonly occuring value
+  # include only segments that have some activity in the last day of the window
+  #
+  segment_most_common as (
+  SELECT
+    seg_id,
+    ssvid,
+    DATE(MAX(last_timestamp)) as day,
+    MIN(first_timestamp) as first_timestamp,
+    MAX(last_timestamp) as last_timestamp,
+    SUM(msg_count) as msg_count,
+    SUM(pos_count) as pos_count,
+    LOGICAL_OR(noise) as noise,
+    mostCommon(ARRAY_CONCAT_AGG(shipname)) as shipname,
+    mostCommon(ARRAY_CONCAT_AGG(callsign)) as callsign,
+    mostCommon(ARRAY_CONCAT_AGG(imo)) as imo,
+    mostCommon(ARRAY_CONCAT_AGG(n_shipname)) as n_shipname,
+    mostCommon(ARRAY_CONCAT_AGG(n_callsign)) as n_callsign,
+    mostCommon(ARRAY_CONCAT_AGG(n_imo)) as n_imo,
+    mostCommon(ARRAY_CONCAT_AGG(shiptype)) as shiptype
+  FROM
+    segments
+  GROUP BY
+    ssvid, seg_id
+  HAVING
+    day = processDate()
+  ),
+  #
+  # Compute most common identity values by ssvid (combine all segments together)
+  #
+  ssvid_most_common as (
+  SELECT
+    ssvid,
+    mostCommon(ARRAY_CONCAT_AGG(n_shipname)) as n_shipname,
+    mostCommon(ARRAY_CONCAT_AGG(n_callsign)) as n_callsign,
+    mostCommon(ARRAY_CONCAT_AGG(n_imo)) as n_imo,
+    mostCommon(ARRAY_CONCAT_AGG(shiptype)) as shiptype
+  FROM
+    segments
+  GROUP BY
+    ssvid
+  ),
+
+  #
+  # Exclude segments that are "noise" and should be ignored for the overlap test
+  #
+  good_segs as (
+  SELECT
+    seg_id,
+    ssvid,
+    first_timestamp,
+    last_timestamp
+  FROM
+    segments
+  WHERE
+    NOT noise AND msg_count > 3
+  ),
+  #
+  # Order all the good segments within a single SSVID and capture the start timestamp of the following segment
+  #
+  overlap_segs as (
+  SELECT
+    seg_id,
+    ssvid,
+    last_timestamp as end_timestamp,
+    LEAD(first_timestamp) OVER (PARTITION BY ssvid ORDER BY first_timestamp) as next_start_timestamp
+  FROM
+    good_segs
+  ),
+  #
+  #  Find SSVIDs that do not have any (non-noise) segments that overlap in time
+  #
+  no_overlap_ssvid AS (
+    SELECT
+      ssvid,
+      COUNTIF(end_timestamp > next_start_timestamp) AS overlap_count
+    FROM
+      overlap_segs
+    GROUP BY
+      ssvid
+    HAVING
+      overlap_count = 0
+  ),
+  #
+  # Find the ssvids that have a single dominant identity, and compute the ssvid-level vessel_id
+  #
+  single_ident_ssvid as (
+  SELECT
+    ssvid,
+    vesselId(ssvid, n_imo.value, n_shipname.value, n_callsign.value) as ssvid_vessel_id
+  FROM
+    ssvid_most_common
+  WHERE
+    LEAST(
+      IFNULL(n_shipname.freq, 1.0),
+      IFNULL(n_callsign.freq, 1.0),
+      IFNULL(n_imo.freq, 1.0),
+      IFNULL(shiptype.freq, 1.0)
+     ) > singleIdentMinFreq()
+  ),
+  #
+  # Get ssvid identites that have no overlapping segments and only one identity
+  #
+  no_overlap_single_ident_ssvid as (
+  SELECT
+    *
+  FROM
+    single_ident_ssvid JOIN no_overlap_ssvid USING (ssvid)
+  ),
+  #
+  # Set the segment vessel_id. If the ssvid has no overlaps and only one identity, then use the ssvid's vessel_id
+  # otherwise create a vessel_id using the most common identity values in the segment
+  #
+  segment_vessel_day as (
+  SELECT
+    IFNULL(ssvid_vessel_id, vesselId(ssvid, n_imo.value, n_shipname.value, n_callsign.value)) as vessel_id,
+    ssvid_vessel_id is not NULL as single_ident_ssvid,
+    segment_most_common.*
+  FROM segment_most_common LEFT JOIN no_overlap_single_ident_ssvid USING (ssvid)
+  )
+
+
+SELECT
+  *
+FROM
+   segment_vessel_day

--- a/assets/util.sql.j2
+++ b/assets/util.sql.j2
@@ -1,0 +1,55 @@
+#standardSQL
+#
+# Utility Bigquery Functions
+#
+
+
+CREATE TEMP FUNCTION YYYYMMDD(d DATE) AS (
+  # Format a date as YYYYMMDD
+  # e.g. DATE('2018-01-01') => '20180101'
+
+  FORMAT_DATE('%Y%m%d', d)
+);
+
+
+CREATE TEMP FUNCTION mostCommon(arr ARRAY<STRUCT<value STRING, count INT64>>) AS (
+  #
+  # Simple map/reduce that finds the most common string value in a list of (string,int) tuples
+  # Finds and returns the string with the highest sum of the associated integer values, and
+  # computes the frequency of that value relative to the total of all values in the list
+
+  (
+   select as struct
+     value,
+     count,
+     count/(select sum(r.count) from unnest(arr) as r ) as freq
+   from (
+     select as struct r.value as value, sum(r.count) as count from unnest(arr) as r group by r.value order by count DESC limit 1
+     )
+   )
+);
+
+
+CREATE TEMP FUNCTION vesselID(ssvid STRING, imo STRING, shipname STRING, callsign STRING) AS (
+  #
+  # Format a vessel_id as a guid xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx using
+  # ssvid, imo, shipname, callsign
+  #
+  (
+    SELECT
+      FORMAT('%s-%s-%s-%s-%s',
+        SUBSTR(vessel_id, 1,  9),
+        SUBSTR(vessel_id, 9,  4),
+        SUBSTR(vessel_id, 13, 4),
+        SUBSTR(vessel_id, 17, 4),
+        SUBSTR(vessel_id, 21, 12)
+      ) as vessel_id
+    FROM (
+      SELECT
+        IF(imo IS NOT NULL,
+          TO_HEX(MD5(FORMAT("AIS|%s|%s|%s|%s", ssvid, imo, '', ''))),
+          TO_HEX(MD5(FORMAT("AIS|%s|%s|%s|%s", ssvid, '', IFNULL(shipname, ''), IFNULL(callsign, ''))))
+        ) AS vessel_id
+    )
+  )
+);

--- a/assets/vessel_info.schema.json
+++ b/assets/vessel_info.schema.json
@@ -1,0 +1,228 @@
+[
+  {
+    "mode": "NULLABLE",
+    "name": "vessel_id",
+    "type": "STRING",
+    "description": "unique vessel id.  This table has one row per vessel_id"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "ssvid",
+    "type": "STRING",
+    "description": "source specific vessel id.  This is the transponder id, and for AIS this is the MMSI"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "first_timestamp",
+    "type": "TIMESTAMP",
+    "description": "Timestamp of the first message in the segment"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "last_timestamp",
+    "type": "TIMESTAMP",
+    "description": "Timestamp of the last message in the segment"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "msg_count",
+    "type": "INTEGER",
+    "description": "Total number of messages in the segment, including identiy messages and positional messages"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "pos_count",
+    "type": "INTEGER",
+    "description": "Total number or positional messages in the segment.   Consider filtering out messages in segments with only a small number of positional messagess"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "noise",
+    "type": "BOOLEAN",
+    "description": "If true, then this is a noise segment, usually because of an invalid lat or lon value.  Messages in these segments should be filtered out"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the this field value occured for this vessel"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "freq",
+        "type": "FLOAT",
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "shipname",
+    "type": "RECORD",
+    "description": "Most commonly occuring shipname (unnormalized) for this vessel"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the this field value occured for this vessel"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "freq",
+        "type": "FLOAT",
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "callsign",
+    "type": "RECORD",
+    "description": "Most commonly occuring callsign (unnormalized) for this vessel"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the this field value occured for this vessel"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "freq",
+        "type": "FLOAT",
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "imo",
+    "type": "RECORD",
+    "description": "Most commonly occuring imo number (unvalidated) for this vessel"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the this field value occured for this vessel"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "freq",
+        "type": "FLOAT",
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "n_shipname",
+    "type": "RECORD",
+    "description": "Most commonly occuring normalized shipname for this vessel"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the this field value occured for this vessel"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "freq",
+        "type": "FLOAT",
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "n_callsign",
+    "type": "RECORD",
+    "description": "Most commonly occuring normalized callsign for this vessel"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the this field value occured for this vessel"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "freq",
+        "type": "FLOAT",
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "n_imo",
+    "type": "RECORD",
+    "description": "Most commonly occuring valid imo number for this vessel"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the this field value occured for this vessel "
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "freq",
+        "type": "FLOAT",
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "shiptype",
+    "type": "RECORD",
+    "description": "Most commonly occuring shiptype for this vessel.  Note that shiptype is already normalized in the source messages."
+  }
+
+]
+

--- a/assets/vessel_info.sql.j2
+++ b/assets/vessel_info.sql.j2
@@ -1,0 +1,115 @@
+#standardSQL
+#
+# Create a vessel info table with one row per vessel_id from segment_identity_daily
+# using seg_id to vesse_id mappings from segment_identity_window
+# Includes the entire time range from the source tables
+#
+#
+# FUNCTIONS
+#
+# Simple map/reduce that finds the most common string value in a list of string,int tuples
+# Finds and returns the string with the highest sum of the associated integer values, and
+# computes the frequency of that value relative to the total of all values in the list
+#
+CREATE TEMP FUNCTION mostCommon(arr ARRAY<STRUCT<value STRING, count INT64>>) AS (
+  (
+   select as struct
+     value,
+     count,
+     count/(select sum(r.count) from unnest(arr) as r ) as freq
+   from (
+     select as struct r.value as value, sum(r.count) as count from unnest(arr) as r group by r.value order by count DESC limit 1
+     )
+   )
+);
+#
+# Build the query
+#
+WITH
+  #
+  # Daily segment identity counts over the entire time range
+  # There is one row per seg_id per day
+  #git
+  segments as (
+  SELECT
+    *
+  FROM
+    `world-fishing-827.scratch_paul_ttl_100.segment_identity_daily_*`
+  ),
+  #
+  # vessel_id mapped to seg_id
+  # note that the source table is a daily snapshot of segmetn activity over a multi-day window
+  # All entries for a given day will have last_timestamp fall within that day (which is the last day of the window)
+  # For any given day, there will be a one-to-one mapping between seg_id and vessel_id, but over
+  # many days, there is a many-to-many mapping
+  #
+  vessels as (
+  SELECT
+    vessel_id,
+    seg_id,
+    last_timestamp
+  FROM
+    `world-fishing-827.scratch_paul_ttl_100.segment_identity_window_*`
+  ),
+  #
+  # Get the day for each row in segments
+  segments_by_day as (
+  SELECT
+    *,
+    TIMESTAMP_TRUNC(last_timestamp, DAY) as day
+  FROM
+    segments
+  ),
+  #
+  # Get the day for each vessel_id to seg_id association
+  vessels_by_day as (
+  SELECT
+    vessel_id,
+    seg_id,
+    TIMESTAMP_TRUNC(last_timestamp, DAY) as day
+  FROM
+    vessels
+  GROUP BY
+    vessel_id,
+    seg_id,
+    day
+  ),
+  segments_by_vessel as (
+  SELECT
+    *
+  FROM
+    segments_by_day JOIN vessels_by_day USING (seg_id, day)
+  ),
+  #
+  # Aggregate daily identity counts over the full time range
+  # group each segment day by vessel_id, so the daily stats for a single segment
+  # are grouped into vessels depending on what vessel_id was assigned to the seg_id
+  # for that day
+  #
+  # reduce each identity field to just the most commonly occuring value
+  vessel_most_common as (
+  SELECT
+    vessel_id,
+    ssvid,
+    MIN(first_timestamp) as first_timestamp,
+    MAX(last_timestamp) as last_timestamp,
+    SUM(msg_count) as msg_count,
+    SUM(pos_count) as pos_count,
+    mostCommon(ARRAY_CONCAT_AGG(shipname)) as shipname,
+    mostCommon(ARRAY_CONCAT_AGG(callsign)) as callsign,
+    mostCommon(ARRAY_CONCAT_AGG(imo)) as imo,
+    mostCommon(ARRAY_CONCAT_AGG(n_shipname)) as n_shipname,
+    mostCommon(ARRAY_CONCAT_AGG(n_callsign)) as n_callsign,
+    mostCommon(ARRAY_CONCAT_AGG(n_imo)) as n_imo,
+    mostCommon(ARRAY_CONCAT_AGG(shiptype)) as shiptype
+  FROM
+    segments_by_vessel
+  GROUP by
+    ssvid,
+    vessel_id
+  )
+
+SELECT
+  *
+FROM
+  vessel_most_common

--- a/assets/vessel_info.sql.j2
+++ b/assets/vessel_info.sql.j2
@@ -5,24 +5,10 @@
 # Includes the entire time range from the source tables
 #
 #
-# FUNCTIONS
-#
-# Simple map/reduce that finds the most common string value in a list of string,int tuples
-# Finds and returns the string with the highest sum of the associated integer values, and
-# computes the frequency of that value relative to the total of all values in the list
-#
-CREATE TEMP FUNCTION mostCommon(arr ARRAY<STRUCT<value STRING, count INT64>>) AS (
-  (
-   select as struct
-     value,
-     count,
-     count/(select sum(r.count) from unnest(arr) as r ) as freq
-   from (
-     select as struct r.value as value, sum(r.count) as count from unnest(arr) as r group by r.value order by count DESC limit 1
-     )
-   )
-);
-#
+
+# Include some utility functions
+{% include 'util.sql.j2' %}
+
 # Build the query
 #
 WITH
@@ -34,11 +20,11 @@ WITH
   SELECT
     *
   FROM
-    `world-fishing-827.scratch_paul_ttl_100.segment_identity_daily_*`
+    `{{ segment_identity_daily }}*`
   ),
   #
   # vessel_id mapped to seg_id
-  # note that the source table is a daily snapshot of segmetn activity over a multi-day window
+  # note that the source table is a daily snapshot of segment activity over a multi-day window
   # All entries for a given day will have last_timestamp fall within that day (which is the last day of the window)
   # For any given day, there will be a one-to-one mapping between seg_id and vessel_id, but over
   # many days, there is a many-to-many mapping
@@ -47,16 +33,16 @@ WITH
   SELECT
     vessel_id,
     seg_id,
-    last_timestamp
+    day
   FROM
-    `world-fishing-827.scratch_paul_ttl_100.segment_identity_window_*`
+    `{{ segment_vessel_daily }}*`
   ),
   #
   # Get the day for each row in segments
   segments_by_day as (
   SELECT
     *,
-    TIMESTAMP_TRUNC(last_timestamp, DAY) as day
+    DATE(last_timestamp) as day
   FROM
     segments
   ),
@@ -66,7 +52,7 @@ WITH
   SELECT
     vessel_id,
     seg_id,
-    TIMESTAMP_TRUNC(last_timestamp, DAY) as day
+    day
   FROM
     vessels
   GROUP BY

--- a/dev-temp/66-refactor-segment-identity/build.sh
+++ b/dev-temp/66-refactor-segment-identity/build.sh
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash

--- a/dev-temp/66-refactor-segment-identity/build.sh
+++ b/dev-temp/66-refactor-segment-identity/build.sh
@@ -1,1 +1,92 @@
 #!/usr/bin/env bash
+# Build an eval dataset in bigquery
+
+set -e
+
+source pipe-tools-utils
+
+THIS_SCRIPT_DIR="$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )"
+EXEC_DIR=${THIS_SCRIPT_DIR}/../../scripts
+
+display_usage() {
+	echo "Available Commands"
+	echo "  fetch_messages"
+	echo "  segment_identity_daily"
+	echo "  segment_vessel_daily"
+	echo "  segment_info"
+	echo "  vessel_info"
+	echo "  segment_vessel"
+	echo "  build_all"
+	}
+
+
+if [[ $# -le 0 ]]
+then
+    display_usage
+    exit 1
+fi
+
+PROJECT=world-fishing-827
+DATASET=66_refactor_seg_ident_ttl100
+SOURCE_DATASET=pipe_production_b
+START_DATE=2018-08-01
+END_DATE=2018-08-03
+WINDOW_DAYS=30
+SINGLE_IDENT_MIN_FREQ=0.99
+
+DATE_RANGE=${START_DATE},${END_DATE}
+
+MESSAGES_TABLE=messages_segmented_
+SEGMENTS_TABLE=segments_
+SOURCE_MESSAGES="${PROJECT}:${SOURCE_DATASET}.${MESSAGES_TABLE}"
+SOURCE_SEGMENTS="${PROJECT}:${SOURCE_DATASET}.${SEGMENTS_TABLE}"
+MESSAGES=${PROJECT}:${DATASET}.${MESSAGES_TABLE}
+SEGMENTS=${PROJECT}:${DATASET}.${SEGMENTS_TABLE}
+SEGMENT_IDENTITY_DAILY=${PROJECT}:${DATASET}.segment_identity_daily_
+SEGMENT_VESSEL_DAILY=${PROJECT}:${DATASET}.segment_vessel_daily_
+SEGMENT_INFO=${PROJECT}:${DATASET}.segment_info
+VESSEL_INFO=${PROJECT}:${DATASET}.vessel_info
+SEGMENT_VESSEL=${PROJECT}:${DATASET}.segment_vessel
+
+
+case $1 in
+  fetch_messages)
+    # Copy source data into working dataset
+    xdaterange ${THIS_SCRIPT_DIR}/fetch_messages.sh ${DATE_RANGE} ${SOURCE_MESSAGES} ${MESSAGES}
+    xdaterange ${THIS_SCRIPT_DIR}/fetch_messages.sh ${DATE_RANGE} ${SOURCE_SEGMENTS} ${SEGMENTS}
+  ;;
+
+  segment_identity_daily)
+    xdaterange ${EXEC_DIR}/segment_identity_daily.sh ${DATE_RANGE} ${MESSAGES} ${SEGMENTS} ${SEGMENT_IDENTITY_DAILY}
+  ;;
+
+  segment_vessel_daily)
+    xdaterange ${EXEC_DIR}/segment_vessel_daily.sh ${DATE_RANGE} ${WINDOW_DAYS} ${SINGLE_IDENT_MIN_FREQ}  \
+      ${SEGMENT_IDENTITY_DAILY} ${SEGMENT_VESSEL_DAILY}
+  ;;
+
+  segment_info)
+    ${EXEC_DIR}/segment_info.sh ${SEGMENT_IDENTITY_DAILY} ${SEGMENT_INFO}
+  ;;
+
+  vessel_info)
+    ${EXEC_DIR}/vessel_info.sh ${SEGMENT_IDENTITY_DAILY} ${SEGMENT_VESSEL_DAILY} ${VESSEL_INFO}
+  ;;
+
+  segment_vessel)
+    ${EXEC_DIR}/segment_vessel.sh  ${SEGMENT_VESSEL_DAILY} ${SEGMENT_VESSEL}
+  ;;
+
+  build_all)
+    ${THIS_SCRIPT_DIR}/build.sh fetch_messages
+    ${THIS_SCRIPT_DIR}/build.sh segment_identity_daily
+    ${THIS_SCRIPT_DIR}/build.sh segment_vessel_daily
+    ${THIS_SCRIPT_DIR}/build.sh segment_info
+    ${THIS_SCRIPT_DIR}/build.sh vessel_info
+    ${THIS_SCRIPT_DIR}/build.sh segment_vessel
+  ;;
+  *)
+    display_usage
+    exit 0
+    ;;
+esac

--- a/dev-temp/66-refactor-segment-identity/fetch_messages.sh
+++ b/dev-temp/66-refactor-segment-identity/fetch_messages.sh
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash

--- a/dev-temp/66-refactor-segment-identity/fetch_messages.sh
+++ b/dev-temp/66-refactor-segment-identity/fetch_messages.sh
@@ -1,1 +1,26 @@
 #!/usr/bin/env bash
+# run fetch_messages.sql.j2
+
+set -e
+
+source pipe-tools-utils
+
+THIS_SCRIPT_DIR="$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )"
+
+
+PROCESS_DATE=$1
+SOURCE=$2
+DEST=$3
+
+YYYYMMDD=$(yyyymmdd ${PROCESS_DATE})
+SOURCE=${SOURCE//:/.}${YYYYMMDD}
+DEST=${DEST}${YYYYMMDD}
+
+SQL=${THIS_SCRIPT_DIR}/fetch_messages.sql.j2
+QUERY=$(jinja2 ${SQL} -D source=${SOURCE})
+
+echo "${QUERY}" | \
+  bq query --headless --max_rows=0 --allow_large_results --replace \
+  --destination_table ${DEST}
+
+bq update  --description "${QUERY}" ${DEST}

--- a/dev-temp/66-refactor-segment-identity/fetch_messages.sql.j2
+++ b/dev-temp/66-refactor-segment-identity/fetch_messages.sql.j2
@@ -1,0 +1,8 @@
+#standardSQL
+
+SELECT
+  *
+FROM
+  `{{ source }}`
+WHERE
+  MOD(FARM_FINGERPRINT(ssvid), 10) = 0

--- a/pipe_segment/__init__.py
+++ b/pipe_segment/__init__.py
@@ -3,7 +3,7 @@ Tools for parsing and normalizing AIS from Orbcomm using dataflow
 """
 
 
-__version__ = '0.2.3'
+__version__ = '0.2.4-dev'
 __author__ = 'Paul Woods'
 __email__ = 'paul@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/pipe-segment'

--- a/pipe_segment/__init__.py
+++ b/pipe_segment/__init__.py
@@ -3,7 +3,7 @@ Tools for parsing and normalizing AIS from Orbcomm using dataflow
 """
 
 
-__version__ = '0.2.4-dev'
+__version__ = '0.2.4'
 __author__ = 'Paul Woods'
 __email__ = 'paul@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/pipe-segment'

--- a/scripts/pipeline.sh
+++ b/scripts/pipeline.sh
@@ -2,3 +2,9 @@
 
 PIPELINE='pipe_segment'
 PIPELINE_VERSION=$(python -c "import pkg_resources; print pkg_resources.get_distribution('${PIPELINE}').version")
+
+# add two spaces the the start of every line
+# usage:
+#   echo "indent this" | indent
+
+indent() { sed 's/^/  /'; }

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -9,8 +9,12 @@ display_usage() {
 	echo "  identity_messages_monthly   generate monthly identity message summaries"
 	echo "                              per segment"
 	echo "  segment_identity            generate monthly vessel_ids per segment"
-	echo "  segment_info                create a segment_info table with one row per segment"
-	}
+	echo "  segment_identity_daily      generate daily summary of identity messages"
+	echo "                              per segment"
+	echo "  segment_vessel_daily        generate daily vessel_ids per segment"
+	echo "  segment_info                create a segment_info table with one row"
+	echo "                              per segment"
+}
 
 
 if [[ $# -le 0 ]]
@@ -23,11 +27,18 @@ fi
 case $1 in
   identity_messages_monthly)
     ${THIS_SCRIPT_DIR}/identity_messages_monthly.sh "${@:2}"
-
   ;;
 
   segment_identity)
     ${THIS_SCRIPT_DIR}/segment_identity.sh "${@:2}"
+  ;;
+
+  segment_identity_daily)
+    xdaterange ${THIS_SCRIPT_DIR}/segment_identity_daily.sh "${@:2}"
+  ;;
+
+  segment_vessel_daily)
+    xdaterange ${THIS_SCRIPT_DIR}/segment_vessel_daily.sh "${@:2}"
   ;;
 
   segment_info)
@@ -35,7 +46,6 @@ case $1 in
   ;;
 
   segment)
-
     python -m pipe_segment "${@:2}"
     ;;
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -14,6 +14,8 @@ display_usage() {
 	echo "  segment_vessel_daily        generate daily vessel_ids per segment"
 	echo "  segment_info                create a segment_info table with one row"
 	echo "                              per segment"
+	echo "  vessel_info                 create a vessel_info table with one row"
+	echo "                              per vessel_id"
 }
 
 
@@ -43,6 +45,10 @@ case $1 in
 
   segment_info)
     ${THIS_SCRIPT_DIR}/segment_info.sh "${@:2}"
+  ;;
+
+  vessel_info)
+    ${THIS_SCRIPT_DIR}/vessel_info.sh "${@:2}"
   ;;
 
   segment)

--- a/scripts/segment_identity.sh
+++ b/scripts/segment_identity.sh
@@ -31,6 +31,8 @@ END_YYYYMMDD=$(yyyymmdd ${END_DATE})
 
 SQL=${ASSETS}/segment_identity.sql.j2
 TABLE_DESC=(
+  "DEPRECATED"
+  " "
   "* Pipeline: ${PIPELINE} ${PIPELINE_VERSION}"
   "* Source: ${INDENTITY_MESSAGES}"
   "* Command:"

--- a/scripts/segment_identity_daily.sh
+++ b/scripts/segment_identity_daily.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -e
+
+source pipe-tools-utils
+
+THIS_SCRIPT_DIR="$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )"
+
+ASSETS=${THIS_SCRIPT_DIR}/../assets
+source ${THIS_SCRIPT_DIR}/pipeline.sh
+
+PROCESS=$(basename $0 .sh)
+ARGS=( PROCESS_DATE MESSAGES_TABLE SEGMENTS_TABLE DEST_TABLE )
+SCHEMA=${ASSETS}/${PROCESS}.schema.json
+SQL=${ASSETS}/${PROCESS}.sql.j2
+TABLE_DESC=(
+  "Daily summary of identity messages by segment"
+  ""
+  "* Pipeline: ${PIPELINE} ${PIPELINE_VERSION}"
+  "* Source: ${MESSAGES_TABLE}"
+  "* Command: $(basename $0)"
+)
+
+display_usage()
+{
+  echo -e "\nUsage:\n${PROCESS}.sh ${ARGS[*]} \n"
+}
+
+if [[ $# -ne ${#ARGS[@]} ]]
+then
+    display_usage
+    exit 1
+fi
+
+ARG_VALUES=("$@")
+PARAMS=()
+for index in ${!ARGS[*]}; do
+  echo ${ARG_VALUES[$index]}
+  declare "${ARGS[$index]}"="${ARG_VALUES[$index]}"
+  PARAMS+=("${ARGS[$index]}=${ARG_VALUES[$index]}")
+done
+
+TABLE_DESC+=(${PARAMS[*]})
+TABLE_DESC=$( IFS=$'\n'; echo "${TABLE_DESC[*]}" )
+YYYYMMDD=$(yyyymmdd ${PROCESS_DATE})
+DEST_TABLE=${DEST_TABLE}${PROCESS_DATE}
+
+
+echo "Publishing ${PROCESS} to ${DEST_TABLE}..."
+echo ""
+echo "Table Description" | indent
+echo "${TABLE_DESC}" | indent
+echo ""
+echo "Executing query..." | indent
+jinja2 ${SQL} \
+   -D messages=${MESSAGES_TABLE//:/.}${YYYYMMDD} \
+   -D segments=${SEGMENTS_TABLE//:/.}${YYYYMMDD} \
+   | bq query --headless --max_rows=0 --allow_large_results --replace \
+     --destination_table ${DEST_TABLE}  | indent
+
+echo ""
+bq update --schema ${SCHEMA} --description "${TABLE_DESC}" ${DEST_TABLE} | indent
+
+echo ""
+echo "DONE ${DEST_TABLE}."

--- a/scripts/segment_identity_daily.sh
+++ b/scripts/segment_identity_daily.sh
@@ -42,7 +42,7 @@ done
 TABLE_DESC+=(${PARAMS[*]})
 TABLE_DESC=$( IFS=$'\n'; echo "${TABLE_DESC[*]}" )
 YYYYMMDD=$(yyyymmdd ${PROCESS_DATE})
-DEST_TABLE=${DEST_TABLE}${PROCESS_DATE}
+DEST_TABLE=${DEST_TABLE}${YYYYMMDD}
 
 
 echo "Publishing ${PROCESS} to ${DEST_TABLE}..."

--- a/scripts/segment_vessel.sh
+++ b/scripts/segment_vessel.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -e
+
+source pipe-tools-utils
+
+THIS_SCRIPT_DIR="$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )"
+
+ASSETS=${THIS_SCRIPT_DIR}/../assets
+source ${THIS_SCRIPT_DIR}/pipeline.sh
+
+PROCESS=$(basename $0 .sh)
+ARGS=( SEGMENT_VESSEL_TABLE DEST_TABLE )
+SCHEMA=${ASSETS}/${PROCESS}.schema.json
+SQL=${ASSETS}/${PROCESS}.sql.j2
+TABLE_DESC=(
+  "Many to many mapping between seg_id, vessel_id and ssvid"
+  ""
+  "* Pipeline: ${PIPELINE} ${PIPELINE_VERSION}"
+  "* Source: ${SEGMENT_VESSEL_TABLE}"
+  "* Command: $(basename $0)"
+)
+
+display_usage()
+{
+  echo -e "\nUsage:\n${PROCESS}.sh ${ARGS[*]} \n"
+}
+
+if [[ $# -ne ${#ARGS[@]} ]]
+then
+    display_usage
+    exit 1
+fi
+
+ARG_VALUES=("$@")
+PARAMS=()
+for index in ${!ARGS[*]}; do
+  echo ${ARG_VALUES[$index]}
+  declare "${ARGS[$index]}"="${ARG_VALUES[$index]}"
+  PARAMS+=("${ARGS[$index]}=${ARG_VALUES[$index]}")
+done
+
+TABLE_DESC+=(${PARAMS[*]})
+TABLE_DESC=$( IFS=$'\n'; echo "${TABLE_DESC[*]}" )
+
+
+echo "Publishing ${PROCESS} to ${DEST_TABLE}..."
+echo ""
+echo "Table Description" | indent
+echo "${TABLE_DESC}" | indent
+echo ""
+echo "Executing query..." | indent
+jinja2 ${SQL} \
+   -D segment_vessel_daily=${SEGMENT_VESSEL_TABLE//:/.} \
+   | bq query --headless --max_rows=0 --allow_large_results --replace \
+     --destination_table ${DEST_TABLE}  | indent
+
+echo ""
+bq update --schema ${SCHEMA} --description "${TABLE_DESC}" ${DEST_TABLE} | indent
+
+echo ""
+echo "DONE ${DEST_TABLE}."

--- a/scripts/segment_vessel_daily.sh
+++ b/scripts/segment_vessel_daily.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -e
+
+source pipe-tools-utils
+
+THIS_SCRIPT_DIR="$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )"
+
+ASSETS=${THIS_SCRIPT_DIR}/../assets
+source ${THIS_SCRIPT_DIR}/pipeline.sh
+
+PROCESS=$(basename $0 .sh)
+ARGS=( PROCESS_DATE WINDOW_DAYS SINGLE_IDENT_MIN_FREQ SEGMENT_IDENTITY_TABLE DEST_TABLE )
+SCHEMA=${ASSETS}/${PROCESS}.schema.json
+SQL=${ASSETS}/${PROCESS}.sql.j2
+TABLE_DESC=(
+  "Daily vessel_id assignement for each segment based on most common identity values occuring in a sliding date range of width WINDOW_DAYS"
+  ""
+  "* Pipeline: ${PIPELINE} ${PIPELINE_VERSION}"
+  "* Source: ${MESSAGES_TABLE}"
+  "* Command: $(basename $0)"
+)
+
+display_usage()
+{
+  echo -e "\nUsage:\n${PROCESS}.sh ${ARGS[*]} \n"
+}
+
+if [[ $# -ne ${#ARGS[@]} ]]
+then
+    display_usage
+    exit 1
+fi
+
+ARG_VALUES=("$@")
+PARAMS=()
+for index in ${!ARGS[*]}; do
+  echo ${ARG_VALUES[$index]}
+  declare "${ARGS[$index]}"="${ARG_VALUES[$index]}"
+  PARAMS+=("${ARGS[$index]}=${ARG_VALUES[$index]}")
+done
+
+TABLE_DESC+=(${PARAMS[*]})
+TABLE_DESC=$( IFS=$'\n'; echo "${TABLE_DESC[*]}" )
+DEST_TABLE=${DEST_TABLE}$(yyyymmdd ${PROCESS_DATE})
+
+
+echo "Publishing ${PROCESS} to ${DEST_TABLE}..."
+echo ""
+echo "Table Description" | indent
+echo "${TABLE_DESC}" | indent
+echo ""
+echo "Executing query..." | indent
+jinja2 ${SQL} \
+   -D date="${PROCESS_DATE}" \
+   -D window_days=${WINDOW_DAYS} \
+   -D single_ident_min_freq=${SINGLE_IDENT_MIN_FREQ} \
+   -D segment_identity_daily=${SEGMENT_IDENTITY_TABLE//:/.} \
+   | bq query --headless --max_rows=0 --allow_large_results --replace \
+     --destination_table ${DEST_TABLE}  | indent
+
+echo ""
+bq update --schema ${SCHEMA} --description "${TABLE_DESC}" ${DEST_TABLE} | indent
+
+echo ""
+echo "DONE ${DEST_TABLE}."

--- a/scripts/vessel_info.sh
+++ b/scripts/vessel_info.sh
@@ -9,14 +9,14 @@ ASSETS=${THIS_SCRIPT_DIR}/../assets
 source ${THIS_SCRIPT_DIR}/pipeline.sh
 
 PROCESS=$(basename $0 .sh)
-ARGS=( SEGMENT_IDENTITY_TABLE DEST_TABLE )
+ARGS=( SEGMENT_IDENTITY_TABLE SEGMENT_VESSEL_TABLE DEST_TABLE )
 SCHEMA=${ASSETS}/${PROCESS}.schema.json
 SQL=${ASSETS}/${PROCESS}.sql.j2
 TABLE_DESC=(
-  "Comprehensive table of all segments for all time.  One row per segement"
+  "Comprehensive table of all vessel_ids for all time.  One row per vessel_id"
   ""
   "* Pipeline: ${PIPELINE} ${PIPELINE_VERSION}"
-  "* Source: ${SEGMENT_IDENTITY_TABLE}"
+  "* Source: ${SEGMENT_VESSEL_TABLE}"
   "* Command: $(basename $0)"
 )
 
@@ -51,6 +51,7 @@ echo ""
 echo "Executing query..." | indent
 jinja2 ${SQL} \
    -D segment_identity_daily=${SEGMENT_IDENTITY_TABLE//:/.} \
+   -D segment_vessel_daily=${SEGMENT_VESSEL_TABLE//:/.} \
    | bq query --headless --max_rows=0 --allow_large_results --replace \
      --destination_table ${DEST_TABLE}  | indent
 


### PR DESCRIPTION
For #65

Refactors the system for assigning vessel_id to a segment.  This fixes a problem where vessel_ids are "orphaned" after being used in pipe_measures because the calendar month `segment_identity` table is  overwritten every month and on the re-write, sometimes a different vessel_id is associated with a seg_id.

This PR changes the system to use a sliding window (configurable, default 30 days) to assign vessel_id daily.  Each day's assignment is preserved.  Then a set of summary tables are built that contain all seg_ids and vessel_ids which can be used for lookup and mapping between seg_id, vessel_id and ssvid.

## Changes
* Update and extend `segment_info` table 
* Deprecate`segment_identity` and `identity_messages_monthly` tables
* Create new intermediate date-sharded tables `segement_identity_daily` and `segment_vessel_daily`
* Create new summary tables `segment_info`, `vessel_info` and `segment_vessel`


### TODO
- [x] Create an evaluation dataset
  First draft is here:  `world-fishing-827:66_refactor_seg_ident_ttl100` containing 10% of ssvids over 3 days
- [ ] Test airflow
- [ ] Run in staging, test there
- [x] Make changes to `pipe_measures` to use the new tables https://github.com/GlobalFishingWatch/pipe-measures/issues/34
