### PR TITLE
Minimum frequency threshold for most common ident value determination

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@ Higher level changes affecting the API or data.
 ---------
 * [#66](https://github.com/GlobalFishingWatch/pipe-segment/pull/66)
   Refactor Segment Identity
+* [#71](https://github.com/GlobalFishingWatch/pipe-segment/pull/71)
+  Add param MOST_COMMON_MIN_FREQ which is used to filter noise values 
+  when determinig the most commonly occuring identity value used to
+  assign vessel_id
 
 0.2.3 - 2018-09-03
 ------------------

--- a/airflow/pipe_segment_dag.py
+++ b/airflow/pipe_segment_dag.py
@@ -118,6 +118,7 @@ def build_dag(dag_id, schedule_interval='@daily', extra_default_args=None, extra
                          '{date_range} '
                          '{window_days} '
                          '{single_ident_min_freq} '
+                         '{most_common_min_freq} '
                          '{project_id}:{pipeline_dataset}.{segment_identity_daily_table} '
                          '{project_id}:{pipeline_dataset}.{segment_vessel_daily_table} '.format(**config)
         )
@@ -127,6 +128,7 @@ def build_dag(dag_id, schedule_interval='@daily', extra_default_args=None, extra
             pool='bigquery',
             bash_command='{docker_run} {docker_image} segment_info '
                          '{project_id}:{pipeline_dataset}.{segment_identity_daily_table} '
+                         '{most_common_min_freq} '
                          '{project_id}:{pipeline_dataset}.{segment_info_table} '.format(**config)
         )
 
@@ -136,6 +138,7 @@ def build_dag(dag_id, schedule_interval='@daily', extra_default_args=None, extra
             bash_command='{docker_run} {docker_image} vessel_info '
                          '{project_id}:{pipeline_dataset}.{segment_identity_daily_table} '
                          '{project_id}:{pipeline_dataset}.{segment_vessel_daily_table} '
+                         '{most_common_min_freq} '
                          '{project_id}:{pipeline_dataset}.{vessel_info_table} '.format(**config)
         )
 
@@ -149,6 +152,8 @@ def build_dag(dag_id, schedule_interval='@daily', extra_default_args=None, extra
 
         for sensor in source_sensors:
             dag >> sensor >> segment
+
+        # TODO: Deprecate identity_messages_monthly and segment_identity
 
         segment >> identity_messages_monthly >> segment_identity >> segment_identity_daily
         segment_identity_daily >> segment_info

--- a/airflow/post_install.sh
+++ b/airflow/post_install.sh
@@ -22,6 +22,7 @@ python $AIRFLOW_HOME/utils/set_default_variables.py \
     segment_vessel_table="segment_vessel" \
     segments_table="segments_" \
     single_ident_min_freq="0.99" \
+    most_common_min_freq="0.05" \
     source_dataset="{{ var.value.PIPELINE_DATASET }}" \
     vessel_info_table="vessel_info" \
     temp_bucket="{{ var.value.TEMP_BUCKET }}"  \

--- a/assets/segment_identity_daily.schema.json
+++ b/assets/segment_identity_daily.schema.json
@@ -37,6 +37,12 @@
   },
   {
     "mode": "NULLABLE",
+    "name": "ident_count",
+    "type": "INTEGER",
+    "description": "Number of identity messages in the segment for this day. Note that some messages can contain both position and identity"
+  },
+  {
+    "mode": "NULLABLE",
     "name": "noise",
     "type": "BOOLEAN",
     "description": "If true, then this is a noise segment, usually because of an invalid lat or lon value.  Messages in these segments should be filtered out"

--- a/assets/segment_identity_daily.sql.j2
+++ b/assets/segment_identity_daily.sql.j2
@@ -47,7 +47,8 @@ WITH
     min(timestamp) as first_timestamp,
     max(timestamp) as last_timestamp,
     COUNT(*) AS msg_count,
-    COUNTIF(lat IS NOT NULL) AS pos_count
+    COUNTIF(lat IS NOT NULL) AS pos_count,
+    COUNTIF(COALESCE(shipname, callsign, imo) IS NOT NULL) as ident_count
   FROM
     messages
   GROUP BY

--- a/assets/segment_info.schema.json
+++ b/assets/segment_info.schema.json
@@ -37,6 +37,12 @@
   },
   {
     "mode": "NULLABLE",
+    "name": "ident_count",
+    "type": "INTEGER",
+    "description": "Number of identity messages in the segment. Note that some messages can contain both position and identity"
+  },
+  {
+    "mode": "NULLABLE",
     "name": "noise",
     "type": "BOOLEAN",
     "description": "If true, then this is a noise segment, usually because of an invalid lat or lon value.  Messages in these segments should be filtered out"

--- a/assets/segment_info.sql.j2
+++ b/assets/segment_info.sql.j2
@@ -7,6 +7,8 @@
 # Include some utility functions
 {% include 'util.sql.j2' %}
 
+CREATE TEMP FUNCTION mostCommonMinFreq() AS ({{most_common_min_freq}});
+
 WITH
   segments as (
   SELECT
@@ -25,14 +27,15 @@ WITH
     MAX(last_timestamp) as last_timestamp,
     SUM(msg_count) as msg_count,
     SUM(pos_count) as pos_count,
+    SUM(ident_count) as ident_count,
     LOGICAL_OR(noise) as noise,
-    mostCommon(ARRAY_CONCAT_AGG(shipname)) as shipname,
-    mostCommon(ARRAY_CONCAT_AGG(callsign)) as callsign,
-    mostCommon(ARRAY_CONCAT_AGG(imo)) as imo,
-    mostCommon(ARRAY_CONCAT_AGG(n_shipname)) as n_shipname,
-    mostCommon(ARRAY_CONCAT_AGG(n_callsign)) as n_callsign,
-    mostCommon(ARRAY_CONCAT_AGG(n_imo)) as n_imo,
-    mostCommon(ARRAY_CONCAT_AGG(shiptype)) as shiptype
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(shipname  )), SUM(ident_count), mostCommonMinFreq()) as shipname,
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(callsign  )), SUM(ident_count), mostCommonMinFreq()) as callsign,
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(imo       )), SUM(ident_count), mostCommonMinFreq()) as imo,
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_shipname)), SUM(ident_count), mostCommonMinFreq()) as n_shipname,
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_callsign)), SUM(ident_count), mostCommonMinFreq()) as n_callsign,
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_imo     )), SUM(ident_count), mostCommonMinFreq()) as n_imo,
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(shiptype  )), SUM(ident_count), mostCommonMinFreq()) as shiptype
   FROM
     segments
   GROUP by

--- a/assets/segment_vessel_daily.sql.j2
+++ b/assets/segment_vessel_daily.sql.j2
@@ -11,6 +11,7 @@ CREATE TEMP FUNCTION processDate() AS (DATE('{{ date }}'));
 CREATE TEMP FUNCTION windowDays() AS ({{ window_days }});
 CREATE TEMP FUNCTION windowStart() AS (DATE_SUB(processDate(), INTERVAL (windowDays() - 1) DAY));
 CREATE TEMP FUNCTION singleIdentMinFreq() AS ({{ single_ident_min_freq }});
+CREATE TEMP FUNCTION mostCommonMinFreq() AS ({{most_common_min_freq}});
 
 # Include some utility functions
 {% include 'util.sql.j2' %}
@@ -46,13 +47,13 @@ WITH
     SUM(msg_count) as msg_count,
     SUM(pos_count) as pos_count,
     LOGICAL_OR(noise) as noise,
-    mostCommon(ARRAY_CONCAT_AGG(shipname)) as shipname,
-    mostCommon(ARRAY_CONCAT_AGG(callsign)) as callsign,
-    mostCommon(ARRAY_CONCAT_AGG(imo)) as imo,
-    mostCommon(ARRAY_CONCAT_AGG(n_shipname)) as n_shipname,
-    mostCommon(ARRAY_CONCAT_AGG(n_callsign)) as n_callsign,
-    mostCommon(ARRAY_CONCAT_AGG(n_imo)) as n_imo,
-    mostCommon(ARRAY_CONCAT_AGG(shiptype)) as shiptype
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(shipname  )), SUM(ident_count), mostCommonMinFreq()) as shipname,
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(callsign  )), SUM(ident_count), mostCommonMinFreq()) as callsign,
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(imo       )), SUM(ident_count), mostCommonMinFreq()) as imo,
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_shipname)), SUM(ident_count), mostCommonMinFreq()) as n_shipname,
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_callsign)), SUM(ident_count), mostCommonMinFreq()) as n_callsign,
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_imo     )), SUM(ident_count), mostCommonMinFreq()) as n_imo,
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(shiptype  )), SUM(ident_count), mostCommonMinFreq()) as shiptype
   FROM
     segments
   GROUP BY
@@ -66,10 +67,10 @@ WITH
   ssvid_most_common as (
   SELECT
     ssvid,
-    mostCommon(ARRAY_CONCAT_AGG(n_shipname)) as n_shipname,
-    mostCommon(ARRAY_CONCAT_AGG(n_callsign)) as n_callsign,
-    mostCommon(ARRAY_CONCAT_AGG(n_imo)) as n_imo,
-    mostCommon(ARRAY_CONCAT_AGG(shiptype)) as shiptype
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_shipname)), SUM(ident_count), mostCommonMinFreq()) as n_shipname,
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_callsign)), SUM(ident_count), mostCommonMinFreq()) as n_callsign,
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_imo     )), SUM(ident_count), mostCommonMinFreq()) as n_imo,
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(shiptype  )), SUM(ident_count), mostCommonMinFreq()) as shiptype
   FROM
     segments
   GROUP BY

--- a/assets/util.sql.j2
+++ b/assets/util.sql.j2
@@ -12,23 +12,35 @@ CREATE TEMP FUNCTION YYYYMMDD(d DATE) AS (
 );
 
 
-CREATE TEMP FUNCTION mostCommon(arr ARRAY<STRUCT<value STRING, count INT64>>) AS (
+CREATE TEMP FUNCTION mostCommon(
+  arr ARRAY<STRUCT<value STRING, count INT64>>
+) AS (
   #
   # Simple map/reduce that finds the most common string value in a list of (string,int) tuples
   # Finds and returns the string with the highest sum of the associated integer values, and
   # computes the frequency of that value relative to the total of all values in the list
 
   (
-   select as struct
+   SELECT as struct
      value,
      count,
      count/(select sum(r.count) from unnest(arr) as r ) as freq
-   from (
-     select as struct r.value as value, sum(r.count) as count from unnest(arr) as r group by r.value order by count DESC limit 1
+   FROM (
+     SELECT as struct r.value as value, sum(r.count) as count
+     FROM unnest(arr) as r group by r.value
+     ORDER BY count DESC
+     LIMIT 1
      )
    )
 );
 
+CREATE TEMP FUNCTION minFreqFilter(
+  record STRUCT<value STRING, count INT64, freq FLOAT64>,
+  total_count INT64,
+  min_freq FLOAT64
+) AS (
+  IF (SAFE_DIVIDE(record.count, total_count) > min_freq, record, NULL)
+);
 
 CREATE TEMP FUNCTION vesselID(ssvid STRING, imo STRING, shipname STRING, callsign STRING) AS (
   #

--- a/assets/vessel_info.sql.j2
+++ b/assets/vessel_info.sql.j2
@@ -9,6 +9,8 @@
 # Include some utility functions
 {% include 'util.sql.j2' %}
 
+CREATE TEMP FUNCTION mostCommonMinFreq() AS ({{most_common_min_freq}});
+
 # Build the query
 #
 WITH
@@ -81,13 +83,13 @@ WITH
     MAX(last_timestamp) as last_timestamp,
     SUM(msg_count) as msg_count,
     SUM(pos_count) as pos_count,
-    mostCommon(ARRAY_CONCAT_AGG(shipname)) as shipname,
-    mostCommon(ARRAY_CONCAT_AGG(callsign)) as callsign,
-    mostCommon(ARRAY_CONCAT_AGG(imo)) as imo,
-    mostCommon(ARRAY_CONCAT_AGG(n_shipname)) as n_shipname,
-    mostCommon(ARRAY_CONCAT_AGG(n_callsign)) as n_callsign,
-    mostCommon(ARRAY_CONCAT_AGG(n_imo)) as n_imo,
-    mostCommon(ARRAY_CONCAT_AGG(shiptype)) as shiptype
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(shipname  )), SUM(ident_count), mostCommonMinFreq()) as shipname,
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(callsign  )), SUM(ident_count), mostCommonMinFreq()) as callsign,
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(imo       )), SUM(ident_count), mostCommonMinFreq()) as imo,
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_shipname)), SUM(ident_count), mostCommonMinFreq()) as n_shipname,
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_callsign)), SUM(ident_count), mostCommonMinFreq()) as n_callsign,
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_imo     )), SUM(ident_count), mostCommonMinFreq()) as n_imo,
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(shiptype  )), SUM(ident_count), mostCommonMinFreq()) as shiptype
   FROM
     segments_by_vessel
   GROUP by

--- a/scripts/segment_info.sh
+++ b/scripts/segment_info.sh
@@ -9,7 +9,7 @@ ASSETS=${THIS_SCRIPT_DIR}/../assets
 source ${THIS_SCRIPT_DIR}/pipeline.sh
 
 PROCESS=$(basename $0 .sh)
-ARGS=( SEGMENT_IDENTITY_TABLE DEST_TABLE )
+ARGS=( SEGMENT_IDENTITY_TABLE MOST_COMMON_MIN_FREQ DEST_TABLE )
 SCHEMA=${ASSETS}/${PROCESS}.schema.json
 SQL=${ASSETS}/${PROCESS}.sql.j2
 TABLE_DESC=(
@@ -51,6 +51,7 @@ echo ""
 echo "Executing query..." | indent
 jinja2 ${SQL} \
    -D segment_identity_daily=${SEGMENT_IDENTITY_TABLE//:/.} \
+   -D most_common_min_freq=${MOST_COMMON_MIN_FREQ} \
    | bq query --headless --max_rows=0 --allow_large_results --replace \
      --destination_table ${DEST_TABLE}
 

--- a/scripts/segment_vessel_daily.sh
+++ b/scripts/segment_vessel_daily.sh
@@ -9,7 +9,7 @@ ASSETS=${THIS_SCRIPT_DIR}/../assets
 source ${THIS_SCRIPT_DIR}/pipeline.sh
 
 PROCESS=$(basename $0 .sh)
-ARGS=( PROCESS_DATE WINDOW_DAYS SINGLE_IDENT_MIN_FREQ SEGMENT_IDENTITY_TABLE DEST_TABLE )
+ARGS=( PROCESS_DATE WINDOW_DAYS SINGLE_IDENT_MIN_FREQ MOST_COMMON_MIN_FREQ SEGMENT_IDENTITY_TABLE DEST_TABLE )
 SCHEMA=${ASSETS}/${PROCESS}.schema.json
 SQL=${ASSETS}/${PROCESS}.sql.j2
 TABLE_DESC=(
@@ -54,6 +54,7 @@ jinja2 ${SQL} \
    -D date="${PROCESS_DATE}" \
    -D window_days=${WINDOW_DAYS} \
    -D single_ident_min_freq=${SINGLE_IDENT_MIN_FREQ} \
+   -D most_common_min_freq=${MOST_COMMON_MIN_FREQ} \
    -D segment_identity_daily=${SEGMENT_IDENTITY_TABLE//:/.} \
    | bq query --headless --max_rows=0 --allow_large_results --replace \
      --destination_table ${DEST_TABLE} 

--- a/scripts/vessel_info.sh
+++ b/scripts/vessel_info.sh
@@ -9,7 +9,7 @@ ASSETS=${THIS_SCRIPT_DIR}/../assets
 source ${THIS_SCRIPT_DIR}/pipeline.sh
 
 PROCESS=$(basename $0 .sh)
-ARGS=( SEGMENT_IDENTITY_TABLE SEGMENT_VESSEL_TABLE DEST_TABLE )
+ARGS=( SEGMENT_IDENTITY_TABLE SEGMENT_VESSEL_TABLE MOST_COMMON_MIN_FREQ DEST_TABLE )
 SCHEMA=${ASSETS}/${PROCESS}.schema.json
 SQL=${ASSETS}/${PROCESS}.sql.j2
 TABLE_DESC=(
@@ -52,6 +52,7 @@ echo "Executing query..." | indent
 jinja2 ${SQL} \
    -D segment_identity_daily=${SEGMENT_IDENTITY_TABLE//:/.} \
    -D segment_vessel_daily=${SEGMENT_VESSEL_TABLE//:/.} \
+   -D most_common_min_freq=${MOST_COMMON_MIN_FREQ} \
    | bq query --headless --max_rows=0 --allow_large_results --replace \
      --destination_table ${DEST_TABLE}
 


### PR DESCRIPTION
Closes #69 

NOTE: THIS PR CONTAINS A SCHEMA CHANGE

## TODO
- [x] Test bash scripts
- [ ] Test airflow

## Description
Added a new parameter that is used for determination of the most common value for each identity value (shipname, callsign, etc.)

This creates a new parameter `MOST_COMMON_MIN_FREQ` which is the minimum frequency required for the most common value to be used. If the frequency of the most common value is below this threshold, then the most common value is set to NULL.

The test looks at the number of times the most common value occurred and dividing by the total number of identity messages that are present in the segment.   The resulting ratio is the "frequency" of that value, and that frequency must be greater than the MOST_COMMON_MIN_FREQ threshold value in order for the corresponding value to be used as the most common value.

The purpose of this is to prevent a value from being taken as the most common when it only occurs a few times in a segment that otherwise has a lot of identity messages.  This happens in #69 when a vessel has a NULL callsign most of the time, but occasionally has a bogus non-null callsign message.  

Note that the frequency in this case is `#occurences of value X / #identity messages in the segment` which is different from the relative frequency of each value in the `freq` column which is `#occurences of value X / #non-null occurences for any value of X`.   

In the case of the singleton callsign when there are 99 other ident messages have a null callsign, the relative frequency will be 1.0 (because there is only one non-null value), but the frequency computed for the threshold test will be 0.01 (because only one out of 100 identify messages had that value)

## Schema Changes
- `segment_identity_daily` has a new field `ident_count`
- `segment_info` has a new field `ident_count`
