### PR TITLE
Ranked vessel_id per segment

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,11 +3,6 @@ Changes
 
 Higher level changes affecting the API or data.
 
-0.3.1-dev 
-------------------
-* [#76](https://github.com/GlobalFishingWatch/pipe-segment/pull/76)
-  Ranked vessel_id per segment in segment_vessel table
-
 0.3.0 - 2018-10-26
 ------------------
 * [#66](https://github.com/GlobalFishingWatch/pipe-segment/pull/66)
@@ -16,6 +11,8 @@ Higher level changes affecting the API or data.
   Add param MOST_COMMON_MIN_FREQ which is used to filter noise values 
   when determinig the most commonly occuring identity value used to
   assign vessel_id
+* [#76](https://github.com/GlobalFishingWatch/pipe-segment/pull/76)
+  Ranked vessel_id per segment in segment_vessel table
 
 0.2.3 - 2018-09-03
 ------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,8 @@ Higher level changes affecting the API or data.
 
 0.3.1-dev 
 ------------------
-
+* [#76](https://github.com/GlobalFishingWatch/pipe-segment/pull/76)
+  Ranked vessel_id per segment in segment_vessel table
 
 0.3.0 - 2018-10-26
 ------------------

--- a/assets/segment_vessel.schema.json
+++ b/assets/segment_vessel.schema.json
@@ -36,5 +36,11 @@
     "name": "last_date",
     "type": "DATE",
     "description": "Latest date when this seg_id was associated with this vessel_id"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "vessel_id_rank",
+    "type": "INT64",
+    "description": "rank of this vessel_id relative to the seg_id. The vessel_id with vessel_id_rank=1 is the 'best' vessel_id for each seg_id"
   }
 ]

--- a/assets/segment_vessel.sql.j2
+++ b/assets/segment_vessel.sql.j2
@@ -11,18 +11,28 @@ WITH
     day
   FROM
     `{{ segment_vessel_daily }}*`
+  ),
+  seg_vessel_ssvid as (
+    SELECT
+      seg_id,
+      ssvid,
+      vessel_id,
+      count(DISTINCT day) as days,
+      min(day) as first_date,
+      max(day) as last_date
+    FROM
+      segments
+    GROUP BY
+      seg_id,
+      ssvid,
+      vessel_id
+  ),
+  ranked_vessel_id as (
+    SELECT
+      *,
+      ROW_NUMBER() OVER (PARTITION BY seg_id ORDER BY last_date DESC, vessel_id) as vessel_id_rank
+    FROM
+      seg_vessel_ssvid
   )
 
-SELECT
-  seg_id,
-  ssvid,
-  vessel_id,
-  count(DISTINCT day) as days,
-  min(day) as first_date,
-  max(day) as last_date
-FROM
-  segments
-GROUP BY
-  seg_id,
-  ssvid,
-  vessel_id
+SELECT * FROM ranked_vessel_id

--- a/assets/vessel_info.sql.j2
+++ b/assets/vessel_info.sql.j2
@@ -15,7 +15,7 @@ WITH
   #
   # Daily segment identity counts over the entire time range
   # There is one row per seg_id per day
-  #git
+  #
   segments as (
   SELECT
     *
@@ -46,31 +46,50 @@ WITH
   FROM
     segments
   ),
+
   #
-  # Get the day for each vessel_id to seg_id association
-  vessels_by_day as (
+  # get the latest date for each seg_id/vessel_id pair
+  #
+  vessel_id_latest_day as (
   SELECT
     vessel_id,
     seg_id,
-    day
+    MAX(day) as latest_day
   FROM
     vessels
   GROUP BY
     vessel_id,
-    seg_id,
-    day
+    seg_id
   ),
+
+  #
+  # Rank vessel_id values for each seg_id with the latest day having the highest rank
+  # and keep only the vessel_id with the highest rank for each seg_id
+  best_vessel_id as (
+    SELECT
+      * except (vessel_id_rank)
+    FROM (
+      SELECT
+        seg_id,
+        vessel_id,
+        ROW_NUMBER() OVER (PARTITION BY seg_id ORDER BY latest_day DESC, vessel_id) as vessel_id_rank
+      FROM
+        vessel_id_latest_day
+    )
+    WHERE vessel_id_rank = 1
+  ),
+
   segments_by_vessel as (
   SELECT
     *
   FROM
-    segments_by_day JOIN vessels_by_day USING (seg_id, day)
+    segments_by_day JOIN best_vessel_id USING (seg_id)
   ),
+
   #
   # Aggregate daily identity counts over the full time range
   # group each segment day by vessel_id, so the daily stats for a single segment
-  # are grouped into vessels depending on what vessel_id was assigned to the seg_id
-  # for that day
+  # are grouped into vessels
   #
   # reduce each identity field to just the most commonly occuring value
   vessel_most_common as (


### PR DESCRIPTION
Closes #75 

**NOTE: THIS PR CONTAINS A SCHEMA CHANGE**

## Description
Add a new column `vessel_id_rank` which is the rank of this vessel_id relative to the seg_id. The vessel_id with vessel_id_rank=1 is the 'best' vessel_id for each seg_id

Querying the the table with 

```sql
SELECT * FROM {{ segment_vessel }}
WHERE vessel_id_rank = 1
```
will result in a one-to-one mapping of seg_id to vessel_id

## Testing

Tested by running 
```console
./scripts/run.sh segment_vessel "pipe_production_b.segment_vessel_daily_" "scratch_paul_ttl_100.segment_vessel"
```
and
```console
./scripts/run.sh vessel_info "pipe_production_b.segment_identity_daily_" "pipe_production_b.segment_vessel_daily_" "scratch_paul_ttl_100.vessel_info"
```
and inspecting the output
