### PR TITLE
Segment info patch for ident_count field

### DIFF
--- a/assets/segment_info.sql.j2
+++ b/assets/segment_info.sql.j2
@@ -12,7 +12,8 @@ CREATE TEMP FUNCTION mostCommonMinFreq() AS ({{most_common_min_freq}});
 WITH
   segments as (
   SELECT
-    *
+    * except (ident_count),
+    IFNULL(ident_count, msg_count - pos_count) as ident_count
   FROM
     `{{ segment_identity_daily }}*`
   ),

--- a/assets/segment_vessel_daily.sql.j2
+++ b/assets/segment_vessel_daily.sql.j2
@@ -25,7 +25,8 @@ WITH
   #
   segments as (
   SELECT
-    *
+    * except (ident_count),
+    IFNULL(ident_count, msg_count - pos_count) as ident_count
   FROM
     `{{ segment_identity_daily }}*`
   WHERE

--- a/assets/vessel_info.sql.j2
+++ b/assets/vessel_info.sql.j2
@@ -20,7 +20,8 @@ WITH
   #
   segments as (
   SELECT
-    *
+    * except (ident_count),
+    IFNULL(ident_count, msg_count - pos_count) as ident_count
   FROM
     `{{ segment_identity_daily }}*`
   ),


### PR DESCRIPTION
Fixes #78 

This is backward-compatibility patch that will address issue #78.  This is not a permanent fix becuase it does not compute `ident_count` correctly, but it is fairly close and better than leaving the value as null.

If we get everything updated in production then we don't need this PR and it should be deleted.

