### PR TITLE
message type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,17 @@
-Changes
-=======
+# Changelog
 
-Higher level changes affecting the API or data.
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a
+Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+* [#80](https://github.com/GlobalFishingWatch/pipe-segment/issues/80) and  [#77](https://github.com/GlobalFishingWatch/pipe-segment/issues/77) Take into account if the message is of type A or B to generate the segment. Uses the change done in [GPSDIO version 0.12](https://github.com/SkyTruth/gpsdio-segment/pull/60)
+
 
 0.3.1 - 2018-12-10
 ------------------

--- a/pipe_segment/transform/segment.py
+++ b/pipe_segment/transform/segment.py
@@ -45,6 +45,14 @@ class Segment(PTransform):
         msg = dict(msg)
         msg['timestamp'] = datetimeFromTimestamp(msg['timestamp'])
         msg['mmsi'] = msg['ssvid']
+        type = msg.get('type')
+        if type is not None:
+            msg['old_type'] = type
+            if (type.startswith('AIS.')):
+                try:
+                    msg['type'] = int(type[4:])
+                except ValueError:
+                    pass
         return msg
 
     @staticmethod
@@ -57,6 +65,10 @@ class Segment(PTransform):
         timestamp = timestampFromDatetime(msg['timestamp'])
         msg['timestamp'] = timestamp
         msg['seg_id'] = seg_id
+        type = msg.get('old_type')
+        if type is not None:
+            msg['type'] = type
+            del msg['old_type']
         del msg['mmsi']
         return msg
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 https://codeload.github.com/GlobalFishingWatch/pipe-tools/tar.gz/v0.1.7#egg=pipe-tools-0.1.7
-https://codeload.github.com/Skytruth/gpsdio-segment/tar.gz/v0.12-dev#egg=gpsdio-segment-0.12-dev
+https://codeload.github.com/Skytruth/gpsdio-segment/tar.gz/v0.12#egg=gpsdio-segment-0.12
 https://codeload.github.com/GlobalFishingWatch/ShipDataProcess/tar.gz/70f52826074b8b65a2811ea3ae626a9373cdb83d#egg=shipdataprocess-0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 https://codeload.github.com/GlobalFishingWatch/pipe-tools/tar.gz/v0.1.7#egg=pipe-tools-0.1.7
-https://codeload.github.com/Skytruth/gpsdio-segment/tar.gz/v0.11#egg=gpsdio-segment-0.11
+https://codeload.github.com/Skytruth/gpsdio-segment/tar.gz/v0.12-dev#egg=gpsdio-segment-0.12-dev
 https://codeload.github.com/GlobalFishingWatch/ShipDataProcess/tar.gz/70f52826074b8b65a2811ea3ae626a9373cdb83d#egg=shipdataprocess-0.5.0

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ DEPENDENCIES = [
     "newlinejson",
     "python-stdnum",
     "pipe-tools==0.1.7",
-    "gpsdio-segment==0.11",
+    "gpsdio-segment==0.12-dev",
     "shipdataprocess==0.5.0",
     "jinja2-cli",
 ]

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ DEPENDENCIES = [
     "newlinejson",
     "python-stdnum",
     "pipe-tools==0.1.7",
-    "gpsdio-segment==0.12-dev",
+    "gpsdio-segment==0.12",
     "shipdataprocess==0.5.0",
     "jinja2-cli",
 ]

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -222,3 +222,39 @@ class TestTransforms():
         assert seg_stats == expected
 
 
+    def test_message_type(self, temp_dir):
+        messages_in = [
+            {"timestamp": as_timestamp("2018-01-01 00:00"),
+             "ssvid": "123456789",
+             "type": "AIS.1",
+             "lon": 0.0,
+             "lat": 0.0},
+            {"timestamp": as_timestamp("2018-01-01 01:00"),
+             "ssvid": "123456789",
+             "type": "AIS.18",
+             "lon": 0.0,
+             "lat": 2.0},
+            {"timestamp": as_timestamp("2018-01-01 02:00"),
+             "ssvid": "123456789",
+             "type": "AIS.1",
+             "lon": 0.0,
+             "lat": 0.5},
+            {"timestamp": as_timestamp("2018-01-01 03:00"),
+             "ssvid": "123456789",
+             "type": "AIS.18",
+             "lon": 0.0,
+             "lat": 1.5},
+            {"timestamp": as_timestamp("2018-01-01 04:00"),
+             "ssvid": "123456789",
+             "type": "AIS.5",
+             "shipname": "Boaty"},
+        ]
+
+        segments_in = []
+        messages_out, segments_out = self._run_segment(messages_in, segments_in, temp_dir=temp_dir)
+        seg_stats = [(seg['seg_id'], seg['message_count'], seg['shipname_most_common']) for seg in segments_out]
+
+        expected = [('123456789-2018-01-01T00:00:00.000000Z', 3, 'Boaty'),
+                    ('123456789-2018-01-01T01:00:00.000000Z', 2, None)]
+        assert seg_stats == expected
+


### PR DESCRIPTION
Closes #80 
Closes #77 
Connects https://github.com/SkyTruth/gpsdio-segment/pull/60

### Changes
Update to gspdio-segment v0.12-dev which includes a change that looks at AIS message type and selects the matching segment with a preference for the same message type.

Updates in pipe-segment involve transforming the `type` field if present from 'AIS.x' to the integer value of x, and then swapping back in the original value on output.

### Testing

Added a unit test to test_transform.py

Also see #77 for a good test case