### PR TITLE
Best vessel_id in segment_info table

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,11 @@ Changes
 
 Higher level changes affecting the API or data.
 
+DEV
+---
+* [#83](https://github.com/GlobalFishingWatch/pipe-segment/pull/83)
+  Add vessel_id field to segment_info table
+
 0.3.1 - 2018-12-10
 ------------------
 * [#66](https://github.com/GlobalFishingWatch/pipe-segment/pull/66)

--- a/airflow/pipe_segment_dag.py
+++ b/airflow/pipe_segment_dag.py
@@ -128,6 +128,7 @@ def build_dag(dag_id, schedule_interval='@daily', extra_default_args=None, extra
             pool='bigquery',
             bash_command='{docker_run} {docker_image} segment_info '
                          '{project_id}:{pipeline_dataset}.{segment_identity_daily_table} '
+                         '{project_id}:{pipeline_dataset}.{segment_vessel_daily_table} '
                          '{most_common_min_freq} '
                          '{project_id}:{pipeline_dataset}.{segment_info_table} '.format(**config)
         )

--- a/assets/segment_info.schema.json
+++ b/assets/segment_info.schema.json
@@ -13,6 +13,13 @@
   },
   {
     "mode": "NULLABLE",
+    "name": "vessel_id",
+    "type": "STRING",
+    "description": "Unique vessel id. Each vessel_id can be associated with many seg_ids, and only one ssvid"
+
+  },
+  {
+    "mode": "NULLABLE",
     "name": "first_timestamp",
     "type": "TIMESTAMP",
     "description": "Timestamp of the first message in the segment"

--- a/assets/segment_info.sql.j2
+++ b/assets/segment_info.sql.j2
@@ -10,12 +10,24 @@
 CREATE TEMP FUNCTION mostCommonMinFreq() AS ({{most_common_min_freq}});
 
 WITH
+
   segments as (
   SELECT
     *
   FROM
     `{{ segment_identity_daily }}*`
   ),
+
+  vessels as (
+  SELECT
+    vessel_id,
+    seg_id,
+    day
+  FROM
+    `{{ segment_vessel_daily }}*`
+  ),
+
+
   #
   # Aggregate daily segment identity counts over the full time range
   # and reduce each identity field to just the most commonly occuring value
@@ -41,9 +53,51 @@ WITH
   GROUP by
     ssvid,
     seg_id
+  ),
+
+  #
+  # get the latest date for each seg_id/vessel_id pair
+  #
+  vessel_id_latest_day as (
+  SELECT
+    vessel_id,
+    seg_id,
+    MAX(day) as latest_day
+  FROM
+    vessels
+  GROUP BY
+    vessel_id,
+    seg_id
+  ),
+
+  #
+  # Rank vessel_id values for each seg_id with the latest day having the highest rank
+  # and keep only the vessel_id with the highest rank for each seg_id
+  best_vessel_id as (
+    SELECT
+      * except (vessel_id_rank)
+    FROM (
+      SELECT
+        seg_id,
+        vessel_id,
+        ROW_NUMBER() OVER (PARTITION BY seg_id ORDER BY latest_day DESC, vessel_id) as vessel_id_rank
+      FROM
+        vessel_id_latest_day
+    )
+    WHERE vessel_id_rank = 1
+  ),
+
+  segment_info as (
+    SELECT
+      vessel_id,
+      segment_most_common.*
+    FROM
+      segment_most_common
+    JOIN
+      best_vessel_id
+    USING
+      (seg_id)
+
   )
 
-SELECT
-  *
-FROM
-  segment_most_common
+SELECT * FROM segment_info

--- a/scripts/segment_info.sh
+++ b/scripts/segment_info.sh
@@ -9,7 +9,7 @@ ASSETS=${THIS_SCRIPT_DIR}/../assets
 source ${THIS_SCRIPT_DIR}/pipeline.sh
 
 PROCESS=$(basename $0 .sh)
-ARGS=( SEGMENT_IDENTITY_TABLE MOST_COMMON_MIN_FREQ DEST_TABLE )
+ARGS=( SEGMENT_IDENTITY_TABLE SEGMENT_VESSEL_DAILY MOST_COMMON_MIN_FREQ DEST_TABLE )
 SCHEMA=${ASSETS}/${PROCESS}.schema.json
 SQL=${ASSETS}/${PROCESS}.sql.j2
 TABLE_DESC=(
@@ -51,6 +51,7 @@ echo ""
 echo "Executing query..." | indent
 jinja2 ${SQL} \
    -D segment_identity_daily=${SEGMENT_IDENTITY_TABLE//:/.} \
+   -D segment_vessel_daily=${SEGMENT_VESSEL_DAILY//:/.} \
    -D most_common_min_freq=${MOST_COMMON_MIN_FREQ} \
    | bq query --headless --max_rows=0 --allow_large_results --replace \
      --destination_table ${DEST_TABLE}


### PR DESCRIPTION
NOTE: THIS PR CONTAINS  A SCHEMA CHANGE

Closes #82 

## TODO
- [ ] Test changes via bash scripts
- [ ] Test airfloe

## Changes

Compute the best_vessel_id value for each segment and include the `vessel_id` in a new field in `segment_info`

The best vessel_id is the one with the latest date of association with the seg_id in `segment-vessel_daily`

This adds a new field to the `segment_info` table schema, but it should be fully backward compatible

## Testing

Tested by running 
```console
./scripts/run.sh \
  segment_info \
  "pipe_production_b.segment_identity_daily_" \
  "pipe_production_b.segment_vessel_daily_" \
  0.05 \
  "scratch_paul_ttl_100.segment_info"
```
and inspecting the output