### PR TITLE
Increase spoofing threshold for segment_vessel_daily

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,9 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 * [#80](https://github.com/GlobalFishingWatch/pipe-segment/issues/80) and  [#77](https://github.com/GlobalFishingWatch/pipe-segment/issues/77) Take into account if the message is of type A or B to generate the segment. Uses the change done in [GPSDIO version 0.12](https://github.com/SkyTruth/gpsdio-segment/pull/60)
 * [#83](https://github.com/GlobalFishingWatch/pipe-segment/pull/83)
   Add vessel_id field to segment_info table
-
+* [#87](https://github.com/GlobalFishingWatch/pipe-segment/issues/87)
+  Increase the noise threshold for determination of spoofing, and parameterize
+  
 0.3.1 - 2018-12-10
 ------------------
 * [#66](https://github.com/GlobalFishingWatch/pipe-segment/pull/66)

--- a/airflow/pipe_segment_dag.py
+++ b/airflow/pipe_segment_dag.py
@@ -119,6 +119,7 @@ def build_dag(dag_id, schedule_interval='@daily', extra_default_args=None, extra
                          '{window_days} '
                          '{single_ident_min_freq} '
                          '{most_common_min_freq} '
+                         '{spoofing_threshold} '
                          '{project_id}:{pipeline_dataset}.{segment_identity_daily_table} '
                          '{project_id}:{pipeline_dataset}.{segment_vessel_daily_table} '.format(**config)
         )

--- a/airflow/post_install.sh
+++ b/airflow/post_install.sh
@@ -21,6 +21,7 @@ python $AIRFLOW_HOME/utils/set_default_variables.py \
     segment_vessel_daily_table="segment_vessel_daily_" \
     segment_vessel_table="segment_vessel" \
     segments_table="segments_" \
+    spoofing_threshold="10" \
     single_ident_min_freq="0.99" \
     most_common_min_freq="0.05" \
     source_dataset="{{ var.value.PIPELINE_DATASET }}" \

--- a/assets/segment_vessel_daily.sql.j2
+++ b/assets/segment_vessel_daily.sql.j2
@@ -12,6 +12,7 @@ CREATE TEMP FUNCTION windowDays() AS ({{ window_days }});
 CREATE TEMP FUNCTION windowStart() AS (DATE_SUB(processDate(), INTERVAL (windowDays() - 1) DAY));
 CREATE TEMP FUNCTION singleIdentMinFreq() AS ({{ single_ident_min_freq }});
 CREATE TEMP FUNCTION mostCommonMinFreq() AS ({{most_common_min_freq}});
+CREATE TEMP FUNCTION spoofingThreshold() AS ({{spoofing_threshold}});
 
 # Include some utility functions
 {% include 'util.sql.j2' %}
@@ -89,7 +90,7 @@ WITH
   FROM
     segments
   WHERE
-    NOT noise AND msg_count > 3
+    NOT noise AND msg_count > spoofingThreshold()
   ),
   #
   # Order all the good segments within a single SSVID and capture the start timestamp of the following segment

--- a/scripts/segment_vessel_daily.sh
+++ b/scripts/segment_vessel_daily.sh
@@ -9,7 +9,7 @@ ASSETS=${THIS_SCRIPT_DIR}/../assets
 source ${THIS_SCRIPT_DIR}/pipeline.sh
 
 PROCESS=$(basename $0 .sh)
-ARGS=( PROCESS_DATE WINDOW_DAYS SINGLE_IDENT_MIN_FREQ MOST_COMMON_MIN_FREQ SEGMENT_IDENTITY_TABLE DEST_TABLE )
+ARGS=( PROCESS_DATE WINDOW_DAYS SINGLE_IDENT_MIN_FREQ MOST_COMMON_MIN_FREQ SPOOFING_THRESHOLD SEGMENT_IDENTITY_TABLE DEST_TABLE )
 SCHEMA=${ASSETS}/${PROCESS}.schema.json
 SQL=${ASSETS}/${PROCESS}.sql.j2
 TABLE_DESC=(
@@ -50,14 +50,16 @@ echo "Table Description" | indent
 echo "${TABLE_DESC}" | indent
 echo ""
 echo "Executing query..." | indent
+
 jinja2 ${SQL} \
    -D date="${PROCESS_DATE}" \
    -D window_days=${WINDOW_DAYS} \
    -D single_ident_min_freq=${SINGLE_IDENT_MIN_FREQ} \
    -D most_common_min_freq=${MOST_COMMON_MIN_FREQ} \
+   -D spoofing_threshold=${SPOOFING_THRESHOLD} \
    -D segment_identity_daily=${SEGMENT_IDENTITY_TABLE//:/.} \
    | bq query --headless --max_rows=0 --allow_large_results --replace \
-     --destination_table ${DEST_TABLE} 
+     --destination_table ${DEST_TABLE}
 
 echo ""
 bq update --schema ${SCHEMA} --description "${TABLE_DESC}" ${DEST_TABLE}


### PR DESCRIPTION
Closes #87 

## TODO
- [x] Test bash script
- [ ] Test airflow 

## Description

In segment_vessel_daily we make a determination whether a single ssvid has a single vessel identity present. Part of this test is determining whether there is any mmsi spoofing (more than one vessel using the same mmsi) in the last 30 days. If there is, then we allow more than one vessel_id to be assigned to a single ssvid.

The threshold for eliminating noise segments in this test is too low and results in false positives, and the value is hard coded in the SQL.

## Changes

* Parameterize so it can be configured in airflow.  New param value is called `spoofing_threshold`
* Change the default value to 10 (was 3) position messages required in a segment before it can be considered a spoofing segment (if it overlaps with another segment)

## Testing

Tested with
```console
./scripts/run.sh \
  segment_vessel_daily \
  2019-01-01 \
  30 \
  0.99 \
  0.05 \
  10 \
  "pipe_production_b.segment_identity_daily_" \
  "scratch_paul_ttl_100.segment_vessel_daily"
```
