### PR TITLE
Single ident ssvid

### DIFF
--- a/assets/segment_identity_daily.schema.json
+++ b/assets/segment_identity_daily.schema.json
@@ -25,6 +25,18 @@
   },
   {
     "mode": "NULLABLE",
+    "name": "first_pos_timestamp",
+    "type": "TIMESTAMP",
+    "description": "Timestamp of the first position message in the segment for this day"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "last_pos_timestamp",
+    "type": "TIMESTAMP",
+    "description": "Timestamp of the last position message in the segment for this day"
+  },
+  {
+    "mode": "NULLABLE",
     "name": "msg_count",
     "type": "INTEGER",
     "description": "Total number of messages (positional and identity messages) in the segment for this day"

--- a/assets/segment_identity_daily.sql.j2
+++ b/assets/segment_identity_daily.sql.j2
@@ -46,6 +46,8 @@ WITH
     seg_id,
     min(timestamp) as first_timestamp,
     max(timestamp) as last_timestamp,
+    min( IF(lat IS NOT NULL, timestamp, null)) AS first_pos_timestamp,
+    max( IF(lat IS NOT NULL, timestamp, null)) AS last_pos_timestamp,
     COUNT(*) AS msg_count,
     COUNTIF(lat IS NOT NULL) AS pos_count,
     COUNTIF(COALESCE(shipname, callsign, imo) IS NOT NULL) as ident_count

--- a/assets/segment_vessel_daily.schema.json
+++ b/assets/segment_vessel_daily.schema.json
@@ -33,13 +33,25 @@
     "mode": "NULLABLE",
     "name": "first_timestamp",
     "type": "TIMESTAMP",
-    "description": "Timestamp of the first message in the segment for this day"
+    "description": "Timestamp of the first message in the segment over the time window"
   },
   {
     "mode": "NULLABLE",
     "name": "last_timestamp",
     "type": "TIMESTAMP",
-    "description": "Timestamp of the last message in the segment for this day"
+    "description": "Timestamp of the last message in the segment over the time window"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "first_pos_timestamp",
+    "type": "TIMESTAMP",
+    "description": "Timestamp of the first position message in the segment over the time window"
+  },
+  {
+    "mode": "NULLABLE",
+    "name": "last_pos_timestamp",
+    "type": "TIMESTAMP",
+    "description": "Timestamp of the last position message in the segment over the time window"
   },
   {
     "mode": "NULLABLE",

--- a/assets/segment_vessel_daily.sql.j2
+++ b/assets/segment_vessel_daily.sql.j2
@@ -105,9 +105,9 @@ WITH
     good_segs
   ),
   #
-  #  Find SSVIDs that do not have any (non-noise) segments that overlap in time
+  #  Find SSVIDs that have any (non-noise) segments that overlap in time
   #
-  no_overlap_ssvid AS (
+  overlap_ssvid AS (
     SELECT
       ssvid,
       COUNTIF(end_timestamp > next_start_timestamp) AS overlap_count
@@ -116,7 +116,7 @@ WITH
     GROUP BY
       ssvid
     HAVING
-      overlap_count = 0
+      overlap_count > 0
   ),
   #
   # Find the ssvids that have a single dominant identity, and compute the ssvid-level vessel_id
@@ -142,7 +142,9 @@ WITH
   SELECT
     *
   FROM
-    single_ident_ssvid JOIN no_overlap_ssvid USING (ssvid)
+    single_ident_ssvid LEFT JOIN overlap_ssvid USING (ssvid)
+  WHERE
+    overlap_ssvid.ssvid is NULL
   ),
   #
   # Set the segment vessel_id. If the ssvid has no overlaps and only one identity, then use the ssvid's vessel_id

--- a/assets/segment_vessel_daily.sql.j2
+++ b/assets/segment_vessel_daily.sql.j2
@@ -45,6 +45,8 @@ WITH
     DATE(MAX(last_timestamp)) as day,
     MIN(first_timestamp) as first_timestamp,
     MAX(last_timestamp) as last_timestamp,
+    MIN(first_pos_timestamp) as first_pos_timestamp,
+    MAX(last_pos_timestamp) as last_pos_timestamp,
     SUM(msg_count) as msg_count,
     SUM(pos_count) as pos_count,
     LOGICAL_OR(noise) as noise,
@@ -85,12 +87,12 @@ WITH
   SELECT
     seg_id,
     ssvid,
-    first_timestamp,
-    last_timestamp
+    first_pos_timestamp,
+    last_pos_timestamp
   FROM
     segments
   WHERE
-    NOT noise AND msg_count > spoofingThreshold()
+    NOT noise AND pos_count > spoofingThreshold()
   ),
   #
   # Order all the good segments within a single SSVID and capture the start timestamp of the following segment
@@ -99,8 +101,8 @@ WITH
   SELECT
     seg_id,
     ssvid,
-    last_timestamp as end_timestamp,
-    LEAD(first_timestamp) OVER (PARTITION BY ssvid ORDER BY first_timestamp) as next_start_timestamp
+    last_pos_timestamp as end_timestamp,
+    LEAD(first_pos_timestamp) OVER (PARTITION BY ssvid ORDER BY first_pos_timestamp) as next_start_timestamp
   FROM
     good_segs
   ),


### PR DESCRIPTION
Closes #91 

## Description
Slight change to the way we determine single_ident_ssvid which is a boolean value in `segment_vessel_daily` which indicates whether the SSVID of the segment contains only one vessel identity within the 30-day time window.

## Changes
* Capture first and last timestamp of position messages only in segment_identity_daily
* Use count of position messages only instead of count of all messages to determine segments which meet the spoofing  threshold (eg at least 10 position messages in a segment0
* Use first and last pos timestamp instead of fist_timestamp and last_timestamp to determine if segments overlap
* Treat an SSVID that contains only small segs that do not meet the spoofing threshold, and does not contain any conflicting identity values as a single_ident_ssvid

## Testing

Tested by running
```console
# segment_identity_daily
./scripts/run.sh segment_identity_daily \
  2018-01-01 \
  pipe_production_b.messages_segmented_ \
  pipe_production_b.segments_ \
  scratch_paul_ttl_100.segment_identity_daily_


# segment_vessel_daily
./scripts/run.sh segment_vessel_daily \
  2018-01-01 \
  30 \
  0.99 \
  0.05 \
  10 \
  scratch_paul_ttl_100.segment_identity_daily_ \
  scratch_paul_ttl_100.segment_vessel_daily_new_
```
and inspecting the output
