### PR TITLE
Add width and length to identity tables

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
   Add vessel_id field to segment_info table
 * [#87](https://github.com/GlobalFishingWatch/pipe-segment/issues/87)
   Increase the noise threshold for determination of spoofing, and parameterize
+* [GlobalFishingWatch/GFW-Tasks#982](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/982)
+  Include width and length of vessels in the segment_info, vessel_info,
+  vessel_identity_daily and segment_identity_daily tables
   
 0.3.1 - 2018-12-10
 ------------------

--- a/assets/segment_identity_daily.schema.json
+++ b/assets/segment_identity_daily.schema.json
@@ -198,6 +198,46 @@
     "name": "shiptype",
     "type": "RECORD",
     "description": "Array of all unique shiptypes for this segment for this day. Note that this field is already normalized in the messages"
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "Unique field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the unique field value occured for this segment for this day"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "length",
+    "type": "RECORD",
+    "description": "Array of all unique length for this segment for this day."
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "Unique field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the unique field value occured for this segment for this day"
+      }
+    ],
+    "mode": "REPEATED",
+    "name": "width",
+    "type": "RECORD",
+    "description": "Array of all unique width for this segment for this day."
   }
 ]
 

--- a/assets/segment_identity_daily.sql.j2
+++ b/assets/segment_identity_daily.sql.j2
@@ -21,7 +21,9 @@ WITH
     n_shipname,
     n_callsign,
     n_imo,
-    shiptype
+    shiptype,
+    width,
+    length
   FROM
     `{{ messages }}`
   ),
@@ -120,6 +122,25 @@ WITH
       ) GROUP BY seg_id
     ),
   #
+  # length: count of occurences per segment for each non-null value
+  #
+  segment_length AS (
+    SELECT seg_id, ARRAY_AGG(STRUCT(value, count)) as length FROM (
+      SELECT seg_id, CAST(length AS STRING) as value, COUNT(*) AS count FROM messages
+      WHERE length IS NOT NULL AND length > 0.0 GROUP BY seg_id, value
+      ) GROUP BY seg_id
+    ),
+  #
+  # width: count of occurences per segment for each non-null value
+  #
+  segment_width AS (
+    SELECT seg_id, ARRAY_AGG(STRUCT(value, count)) as width FROM (
+      SELECT seg_id, CAST(width AS STRING) as value, COUNT(*) AS count FROM messages
+      WHERE width IS NOT NULL AND width > 0.0 GROUP BY seg_id, value
+      ) GROUP BY seg_id
+    ),
+
+  #
   # Stitch all the pieces together for one row per segment
   #
   segment_daily as (
@@ -135,6 +156,8 @@ WITH
       LEFT JOIN segment_n_callsign USING (seg_id)
       LEFT JOIN segment_n_imo USING (seg_id)
       LEFT JOIN segment_shiptype USING (seg_id)
+      LEFT JOIN segment_length USING (seg_id)
+      LEFT JOIN segment_width USING (seg_id)
   )
 
 

--- a/assets/segment_info.schema.json
+++ b/assets/segment_info.schema.json
@@ -72,7 +72,7 @@
         "mode": "NULLABLE",
         "name": "freq",
         "type": "FLOAT",
-        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
       }
     ],
     "mode": "NULLABLE",
@@ -98,7 +98,7 @@
         "mode": "NULLABLE",
         "name": "freq",
         "type": "FLOAT",
-        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
       }
     ],
     "mode": "NULLABLE",
@@ -150,7 +150,7 @@
         "mode": "NULLABLE",
         "name": "freq",
         "type": "FLOAT",
-        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
       }
     ],
     "mode": "NULLABLE",
@@ -202,7 +202,7 @@
         "mode": "NULLABLE",
         "name": "freq",
         "type": "FLOAT",
-        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
       }
     ],
     "mode": "NULLABLE",
@@ -228,13 +228,65 @@
         "mode": "NULLABLE",
         "name": "freq",
         "type": "FLOAT",
-        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
       }
     ],
     "mode": "NULLABLE",
     "name": "shiptype",
     "type": "RECORD",
     "description": "Most commonly occuring shiptype for this segment.  Note that shiptype is already normalized in the source messages."
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the this field value occured for this segment "
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "freq",
+        "type": "FLOAT",
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "length",
+    "type": "RECORD",
+    "description": "Most commonly occuring length for this segment."
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the this field value occured for this segment "
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "freq",
+        "type": "FLOAT",
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "width",
+    "type": "RECORD",
+    "description": "Most commonly occuring width for this segment."
   }
 
 ]

--- a/assets/segment_info.sql.j2
+++ b/assets/segment_info.sql.j2
@@ -47,7 +47,9 @@ WITH
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_shipname)), SUM(ident_count), mostCommonMinFreq()) as n_shipname,
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_callsign)), SUM(ident_count), mostCommonMinFreq()) as n_callsign,
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_imo     )), SUM(ident_count), mostCommonMinFreq()) as n_imo,
-    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(shiptype  )), SUM(ident_count), mostCommonMinFreq()) as shiptype
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(shiptype  )), SUM(ident_count), mostCommonMinFreq()) as shiptype,
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(length    )), SUM(ident_count), mostCommonMinFreq()) as length,
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(width     )), SUM(ident_count), mostCommonMinFreq()) as width
   FROM
     segments
   GROUP by

--- a/assets/segment_vessel_daily.schema.json
+++ b/assets/segment_vessel_daily.schema.json
@@ -89,7 +89,7 @@
         "mode": "NULLABLE",
         "name": "freq",
         "type": "FLOAT",
-        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
       }
     ],
     "mode": "NULLABLE",
@@ -115,7 +115,7 @@
         "mode": "NULLABLE",
         "name": "freq",
         "type": "FLOAT",
-        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
       }
     ],
     "mode": "NULLABLE",
@@ -141,7 +141,7 @@
         "mode": "NULLABLE",
         "name": "freq",
         "type": "FLOAT",
-        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
       }
     ],
     "mode": "NULLABLE",
@@ -167,7 +167,7 @@
         "mode": "NULLABLE",
         "name": "freq",
         "type": "FLOAT",
-        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
       }
     ],
     "mode": "NULLABLE",
@@ -193,7 +193,7 @@
         "mode": "NULLABLE",
         "name": "freq",
         "type": "FLOAT",
-        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
       }
     ],
     "mode": "NULLABLE",
@@ -219,7 +219,7 @@
         "mode": "NULLABLE",
         "name": "freq",
         "type": "FLOAT",
-        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
       }
     ],
     "mode": "NULLABLE",
@@ -245,13 +245,65 @@
         "mode": "NULLABLE",
         "name": "freq",
         "type": "FLOAT",
-        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
       }
     ],
     "mode": "NULLABLE",
     "name": "shiptype",
     "type": "RECORD",
     "description": "Most commonly occuring shiptype for this segment over WINDOW_DAYS.  Note that shiptype is already normalized in the source messages."
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the this field value occured for this segment for this day"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "freq",
+        "type": "FLOAT",
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "width",
+    "type": "RECORD",
+    "description": "Most commonly occuring width for this segment over WINDOW_DAYS."
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the this field value occured for this segment for this day"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "freq",
+        "type": "FLOAT",
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "length",
+    "type": "RECORD",
+    "description": "Most commonly occuring length for this segment over WINDOW_DAYS."
   }
 ]
 

--- a/assets/segment_vessel_daily.sql.j2
+++ b/assets/segment_vessel_daily.sql.j2
@@ -56,7 +56,9 @@ WITH
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_shipname)), SUM(ident_count), mostCommonMinFreq()) as n_shipname,
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_callsign)), SUM(ident_count), mostCommonMinFreq()) as n_callsign,
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_imo     )), SUM(ident_count), mostCommonMinFreq()) as n_imo,
-    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(shiptype  )), SUM(ident_count), mostCommonMinFreq()) as shiptype
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(shiptype  )), SUM(ident_count), mostCommonMinFreq()) as shiptype,
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(length    )), SUM(ident_count), mostCommonMinFreq()) as length,
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(width     )), SUM(ident_count), mostCommonMinFreq()) as width
   FROM
     segments
   GROUP BY

--- a/assets/vessel_info.schema.json
+++ b/assets/vessel_info.schema.json
@@ -53,7 +53,7 @@
         "mode": "NULLABLE",
         "name": "freq",
         "type": "FLOAT",
-        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
       }
     ],
     "mode": "NULLABLE",
@@ -79,7 +79,7 @@
         "mode": "NULLABLE",
         "name": "freq",
         "type": "FLOAT",
-        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
       }
     ],
     "mode": "NULLABLE",
@@ -105,7 +105,7 @@
         "mode": "NULLABLE",
         "name": "freq",
         "type": "FLOAT",
-        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
       }
     ],
     "mode": "NULLABLE",
@@ -131,7 +131,7 @@
         "mode": "NULLABLE",
         "name": "freq",
         "type": "FLOAT",
-        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
       }
     ],
     "mode": "NULLABLE",
@@ -157,7 +157,7 @@
         "mode": "NULLABLE",
         "name": "freq",
         "type": "FLOAT",
-        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
       }
     ],
     "mode": "NULLABLE",
@@ -183,7 +183,7 @@
         "mode": "NULLABLE",
         "name": "freq",
         "type": "FLOAT",
-        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
       }
     ],
     "mode": "NULLABLE",
@@ -209,13 +209,65 @@
         "mode": "NULLABLE",
         "name": "freq",
         "type": "FLOAT",
-        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicaates that this was the only value"
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
       }
     ],
     "mode": "NULLABLE",
     "name": "shiptype",
     "type": "RECORD",
     "description": "Most commonly occuring shiptype for this vessel.  Note that shiptype is already normalized in the source messages."
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the this field value occured for this vessel "
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "freq",
+        "type": "FLOAT",
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "length",
+    "type": "RECORD",
+    "description": "Most commonly occuring length for this vessel."
+  },
+  {
+    "fields": [
+      {
+        "mode": "NULLABLE",
+        "name": "value",
+        "type": "STRING",
+        "description": "field value"
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "count",
+        "type": "INTEGER",
+        "description": "Number of times the this field value occured for this vessel "
+      },
+      {
+        "mode": "NULLABLE",
+        "name": "freq",
+        "type": "FLOAT",
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
+      }
+    ],
+    "mode": "NULLABLE",
+    "name": "width",
+    "type": "RECORD",
+    "description": "Most commonly occuring width for this vessel."
   }
 
 ]

--- a/assets/vessel_info.sql.j2
+++ b/assets/vessel_info.sql.j2
@@ -108,7 +108,9 @@ WITH
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_shipname)), SUM(ident_count), mostCommonMinFreq()) as n_shipname,
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_callsign)), SUM(ident_count), mostCommonMinFreq()) as n_callsign,
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_imo     )), SUM(ident_count), mostCommonMinFreq()) as n_imo,
-    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(shiptype  )), SUM(ident_count), mostCommonMinFreq()) as shiptype
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(shiptype  )), SUM(ident_count), mostCommonMinFreq()) as shiptype,
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(length    )), SUM(ident_count), mostCommonMinFreq()) as length,
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(width     )), SUM(ident_count), mostCommonMinFreq()) as width
   FROM
     segments_by_vessel
   GROUP by


### PR DESCRIPTION
Closes https://github.com/GlobalFishingWatch/GFW-Tasks/issues/982

Now that we have the length and width from both Spire and Orbcomm, we want to introduce that information in the segment_info and vessel_info tables. Only length and width that are not null and that are greater than 0 will be taken into account.

### Testing

Created the following tables:
world-fishing-827:scratch_enrique_ttl_60_days.segment_identity_daily_20120101
world-fishing-827:scratch_enrique_ttl_60_days.segment_info
world-fishing-827:scratch_enrique_ttl_60_days.vessel_info
world-fishing-827:scratch_enrique_ttl_60_days.segment_vessel_daily_20120101
