### PR TITLE
1000 dropped messages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 ## [Unreleased]
 
 ### Changed
+* [GlobalFishingWatch/GFW-Tasks#1000](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/1000) Forces ordering when serializing and deserializing segmenter state each day so that the segmenter state timestamp is correctly calculated.
 
 ## v1.0.0 - 2019-03-28
 


### PR DESCRIPTION
Connects https://github.com/GlobalFishingWatch/GFW-Tasks/issues/1000

This fixes 2 separate issues which were causing a lack of messages downstream:

* The segmenter state messages are not guaranteed to be ordered by time. As a result, the calculations to extract the last positional message and the last message when serializing the state each day failed. We now force the messages to be sorted by timestamp. This doesn't have an impact in performance since the segmenter state doesn't really accumulate messages, the `msgs` property is a virtual property which always contains 5 messages only.
* There was a typo in the deserialization of the segmenter state, which caused the same message to be included twice.