### PR TITLE
Uses start_time of default_args instead of pipeline_start_date Airflow variable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,14 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v3.0.4 - 2020-06-18
+
+### Changed
+
+* [GlobalFishingWatch/gfw-eng-task#56](https://github.com/GlobalFishingWatch/gfw-eng-tasks/issues/56): Changes
+    the use of the Airflow Variables `PIPELINE_START_DATE` to the value
+    that is stored in `defaults_args` as `start_date`.
+
 ## v3.0.3 - 2020-06-11
 
 ### Changed

--- a/airflow/pipe_segment_dag.py
+++ b/airflow/pipe_segment_dag.py
@@ -34,7 +34,7 @@ class PipeSegmentDagFactory(DagFactory):
                     command='{docker_run} {docker_image} segment'.format(**config),
                     startup_log_file=pp.join(Variable.get('DATAFLOW_WRAPPER_LOG_PATH'), 'pipe_segment/segment.log'),
                     date_range='{date_range}'.format(**config),
-                    pipeline_start_date=Variable.get('PIPELINE_START_DATE'),
+                    pipeline_start_date=self.default_args['start_date'].strftime("%Y-%m-%d"),
                     source=','.join(source_paths),
                     msg_dest='bq://{project_id}:{pipeline_dataset}.{messages_table}'.format(**config),
                     legacy_seg_v1_dest='bq://{project_id}:{pipeline_dataset}.{legacy_segment_v1_table}'.format(**config),

--- a/pipe_segment/__init__.py
+++ b/pipe_segment/__init__.py
@@ -3,7 +3,7 @@ Tools for parsing and normalizing AIS from Orbcomm using dataflow
 """
 
 
-__version__ = '3.0.3'
+__version__ = '3.0.4'
 __author__ = 'Paul Woods'
 __email__ = 'paul@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/pipe-segment'


### PR DESCRIPTION
Related with> https://github.com/GlobalFishingWatch/gfw-eng-tasks/issues/56

There is needed to change the way the `start_date` is fullfiled.
Replaces the use of the Airflow Variables `PIPELINE_START_DATE` to the value that is stored in `defaults_args` as start_date.
