### PR TITLE
Updates gpsdio-segment to 0.20.2 which supports back and forward time identities

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,13 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [UNRELEASED]
+
+### Changed
+
+* [PIPELINE-144](https://globalfishingwatch.atlassian.net/browse/PIPELINE-144):
+  Changes `gpsdio-segment` version to use the latest fixed version `0.20.2`.
+
 ## v3.0.6 - 2020-10-06
 
 ### Changed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-https://codeload.github.com/GlobalFishingWatch/gpsdio-segment/tar.gz/0.20.1#egg=gpsdio-segment
+https://codeload.github.com/GlobalFishingWatch/gpsdio-segment/tar.gz/0.20.2#egg=gpsdio-segment
 https://codeload.github.com/GlobalFishingWatch/pipe-tools/tar.gz/v3.1.2#egg=pipe-tools
 https://codeload.github.com/GlobalFishingWatch/ShipDataProcess/tar.gz/06b8495f55c6a44306ca9865b4c07d51d7ad5a7b#egg=shipdataprocess


### PR DESCRIPTION
Connects to https://globalfishingwatch.atlassian.net/browse/PIPELINE-116.

Updates `gpsdio-segment` to `0.20.2` which includes a hotfix allowing identities to be assigned to segments forwards and backwards in time.