### PR TITLE
PIPELINE-155: Adds segment identity check

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,11 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [UNRELEASED]
 
+### Added
+
+* [Data Pipeline/PIPELINE-155](https://globalfishingwatch.atlassian.net/browse/PIPELINE-155):
+  Adds a new data quality step for segment identity metrics.
+
 ## v3.0.7 - 2020-10-26
 
 ### Added

--- a/airflow/pipe_segment_dag.py
+++ b/airflow/pipe_segment_dag.py
@@ -1,8 +1,9 @@
 from airflow import DAG
 from airflow.models import Variable
-
+from airflow.contrib.operators.bigquery_check_operator import BigQueryCheckOperator
 from airflow_ext.gfw.models import DagFactory
 from airflow_ext.gfw.operators.dataflow_operator import DataFlowDirectRunnerOperator
+from airflow_ext.gfw import config as config_tools
 
 import posixpath as pp
 
@@ -54,6 +55,27 @@ class PipeSegmentDagFactory(DagFactory):
                 )
             )
 
+            # It would be nice to have a nodash version of source date range in airflow-gfw instead
+            start_date_nodash, end_date_nodash = [x.replace('-', '') for x in self.source_date_range()]
+
+            segment_identity_check = BigQueryCheckOperator(
+                task_id='segment_identity_check',
+                sql=
+                """
+                    SELECT
+                      if(COUNTIF(ARRAY_LENGTH(shipnames) > 0) / COUNT(*) < {segment_identity_threshold}, 1, 0)
+                    FROM
+                      `{project_id}.{pipeline_dataset}.{segments_table}*`
+                    WHERE
+                      _table_suffix between '{start_date_nodash}' and '{end_date_nodash}'
+                      AND message_count > {spoofing_threshold}
+                      AND last_msg_timestamp BETWEEN timestamp AND TIMESTAMP_ADD(timestamp, INTERVAL 1 DAY)
+                """.format(**config, start_date_nodash=start_date_nodash, end_date_nodash=end_date_nodash),
+                use_legacy_sql=False,
+                retries=0,
+                on_failure_callback=config_tools.failure_callback_gfw,
+            )
+
             segment_identity_daily = DataFlowDirectRunnerOperator(
                 task_id='segment_identity_daily',
                 py_file=Variable.get('DATAFLOW_WRAPPER_STUB'),
@@ -98,7 +120,9 @@ class PipeSegmentDagFactory(DagFactory):
             for sensor in source_sensors:
                 dag >> sensor >> segment
 
-            segment >> segment_identity_daily
+            segment >> segment_identity_check
+
+            segment_identity_check >> segment_identity_daily
 
             segment_identity_daily >> segment_vessel_daily
 

--- a/airflow/post_install.sh
+++ b/airflow/post_install.sh
@@ -31,6 +31,8 @@ python $AIRFLOW_HOME/utils/set_default_variables.py \
     vessel_info_table="vessel_info" \
     temp_bucket="{{ var.value.TEMP_BUCKET }}" \
     window_days="30" \
+    max_gap_size_value="24" \
+    segment_identity_threshold="0.8" \
 
 
 echo "Installation Complete"

--- a/airflow/post_install.sh
+++ b/airflow/post_install.sh
@@ -31,7 +31,6 @@ python $AIRFLOW_HOME/utils/set_default_variables.py \
     vessel_info_table="vessel_info" \
     temp_bucket="{{ var.value.TEMP_BUCKET }}" \
     window_days="30" \
-    max_gap_size_value="24" \
     segment_identity_threshold="0.8" \
 
 


### PR DESCRIPTION
Related to https://globalfishingwatch.atlassian.net/browse/PIPELINE-155

The identity check step is run after the segment step is done, and checks that a configurable percentage of the segments that had messages in the processed days have identity information.