### PR TITLE
Fixes little issue, source table was not formatting from template and throw error

### DIFF
--- a/Dockerfile-worker
+++ b/Dockerfile-worker
@@ -1,4 +1,4 @@
-FROM apache/beam_python3.7_sdk:2.35.0
+FROM apache/beam_python3.7_sdk:2.40.0
 
 # Setup local application dependencies
 COPY ./requirements-worker.txt ./

--- a/pipe_segment/transform/satellite_offsets.py
+++ b/pipe_segment/transform/satellite_offsets.py
@@ -65,7 +65,7 @@ class SatelliteOffsets(PTransform):
                      ROW_NUMBER() OVER (PARTITION BY ssvid, receiver, EXTRACT(MINUTE FROM timestamp)
                                 ORDER by ABS(EXTRACT(MICROSECOND FROM timestamp) - 30), receiver,
                                 lon, lat, speed, course) rn
-              FROM `{self.source_table}*`
+              FROM `{source}*`
               WHERE _table_suffix BETWEEN "{start_window:%Y%m%d}" AND "{end_window:%Y%m%d}"
                 AND lat IS NOT NULL AND lon IS NOT NULL 
                 AND ABS(lat) <= 90 AND ABS(lon) <= 180
@@ -248,7 +248,7 @@ class SatelliteOffsets(PTransform):
             ORDER BY receiver, hour
         """
         for start_window, end_window in self._get_query_windows():
-            query = template.format(start_window=start_window, end_window=end_window)
+            query = template.format(source=self.source_table, start_window=start_window, end_window=end_window)
             yield io.Read(
                 io.gcp.bigquery.BigQuerySource(query=query, use_standard_sql=True)
             )

--- a/requirements-scheduler.txt
+++ b/requirements-scheduler.txt
@@ -1,4 +1,4 @@
-apache-beam[gcp]==2.35.0
+apache-beam[gcp]==2.40.0
 pytest==6.2.5
 jinja2-cli==0.8.2
 numpy<1.20.0


### PR DESCRIPTION
Issue reported:
```
 Traceback (most recent call last):
(...)
  File "/opt/project/pipe_segment/transform/satellite_offsets.py", line 48, in <listcomp>
    xs | "SatOffsets{}".format(ndx) >> src
  File "/opt/project/pipe_segment/transform/satellite_offsets.py", line 251, in _sat_offset_iter
    query = template.format(start_window=start_window, end_window=end_window)
KeyError: 'self'
```
Solution:
- Adds `source` as variable in the template for satellite_offsets.

Output:
- The dataset that contains the year 2020 run in backfill mode: `pipe_ais_test_20220720_backfill_internal` & `pipe_ais_test_20220720_backfill_published`.
- The dataset that contains the year 2020 run in monthly mode: `pipe_ais_test_20220720_monthly_internal` & `pipe_ais_test_20220720_monthly_published`.