### PR TITLE
Update the version of Apache beam to 2.40.0

### DIFF
--- a/Dockerfile-worker
+++ b/Dockerfile-worker
@@ -1,4 +1,4 @@
-FROM apache/beam_python3.7_sdk:2.35.0
+FROM apache/beam_python3.7_sdk:2.40.0
 
 # Setup local application dependencies
 COPY ./requirements-worker.txt ./

--- a/requirements-scheduler.txt
+++ b/requirements-scheduler.txt
@@ -1,4 +1,4 @@
-apache-beam[gcp]==2.35.0
+apache-beam[gcp]==2.40.0
 pytest==6.2.5
 jinja2-cli==0.8.2
 numpy<1.20.0


### PR DESCRIPTION
We are currently using the AB version 2.35.0, but it [ends support December 29, 2022](https://cloud.google.com/dataflow/docs/support/sdk-version-support-status).
This affect to all the Dataflow jobs that we are running. In particular for the segment step, they are the `segment` and the `segment_identity_daily`.
I run same baby_pipeline for year 2020, and the outputs were:
- backfill mode: `pipe_ais_test_20220721_backfill_internal` & `pipe_ais_test_20220721_backfill_published`.
- monthly mode: `pipe_ais_test_20220721_monthly_internal` & `pipe_ais_test_20220721_monthly_published`.

**NOTE**: Merge this PR first than #127 . Then merge #127  to `develop`.

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-914