### PR TITLE
Pipe-2.5: Increment AB version to 2.40 to maintain DF SDK support.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,13 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [UNRELEASED]
 
+## v3.2.2 - 2022-07-21
+
+### Changed
+
+* [PIPELINE-914](https://globalfishingwatch.atlassian.net/browse/PIPELINE-914): Changes
+  version of `Apache Beam` from `2.35.0` to [2.40.0](https://beam.apache.org/blog/beam-2.40.0/).
+
 ## v3.2.1 - 2022-04-19
 
 ### Removed

--- a/Dockerfile-worker
+++ b/Dockerfile-worker
@@ -1,4 +1,4 @@
-FROM apache/beam_python3.7_sdk:2.35.0
+FROM apache/beam_python3.7_sdk:2.40.0
 
 # Setup local application dependencies
 COPY ./requirements-worker.txt ./

--- a/pipe_segment/__init__.py
+++ b/pipe_segment/__init__.py
@@ -3,7 +3,7 @@ Tools for parsing and normalizing AIS from Orbcomm using dataflow
 """
 
 
-__version__ = '3.2.1'
+__version__ = '3.2.2'
 __author__ = 'Paul Woods'
 __email__ = 'paul@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/pipe-segment'

--- a/requirements-scheduler.txt
+++ b/requirements-scheduler.txt
@@ -1,3 +1,3 @@
-apache-beam[gcp]==2.35.0
+apache-beam[gcp]==2.40.0
 pytest==6.2.5
 jinja2-cli==0.8.2


### PR DESCRIPTION
* We are currently using the AB version `2.35.0`, but it ends support December 29, 2022.
This affect to all the Dataflow jobs that we are running. In particular for the segment step, they are the `segment` and the `segment_identity_daily`.

- Tested using `2012-01-01` getting equal results.
- Tested using `2012-01-02` getting difference of `~0.013%`. I see new run closes more segments, messages count are ok.

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-914