### PR TITLE
Fixed write of the segment_identity_daily_ table when is in backfill mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,15 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [UNRELEASED]
 
+## v3.2.3 - 2022-08-02
+
+### Changed
+
+* [PIPELINE-946](https://globalfishingwatch.atlassian.net/browse/PIPELINE-946): Changes
+  how the `segment_identity_daily_` table was being saved. Issue detected when
+  running in back-fill mode, only saves one shard per backfill. Fix implies
+  saving one shard per day, priorities `last_timestamp` > `to_ts` > `from_ts`.
+
 ## v3.2.2 - 2022-07-21
 
 ### Changed

--- a/pipe_segment/__init__.py
+++ b/pipe_segment/__init__.py
@@ -3,7 +3,7 @@ Tools for parsing and normalizing AIS from Orbcomm using dataflow
 """
 
 
-__version__ = '3.2.2'
+__version__ = '3.2.3'
 __author__ = 'Paul Woods'
 __email__ = 'paul@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/pipe-segment'

--- a/pipe_segment/segment_identity/pipeline.py
+++ b/pipe_segment/segment_identity/pipeline.py
@@ -354,11 +354,12 @@ class SegmentIdentityPipeline:
 
     @property
     def dest_segment_identity(self):
-        from_ts, _ = self.date_range
+        from_ts, to_ts = self.date_range
         return write_sink(
             self.options.dest_segment_identity,
             self.dest_segment_identity_schema,
             timezoneToDatetime(from_ts),
+            timezoneToDatetime(to_ts),
             "Daily segments identity processed in segment step."
         )
 


### PR DESCRIPTION
The `segment_identity_daily_` table should be build following the steps:
1. Read the segments
2. Summarize the identifiers.
3. Write the segment identities per day. 

In the last step, It occurs when running in a **non daily** mode schedule interval, the process stores only one shard having all the summary of identities in it, in particular, the beginning of the date range. Ex: if period is `[2022-01-01, 2022-03-01]` then the process outputs the table `segment_identitiy_daily_20220101` with only one shard.

Later, it generates issues when trying to build the `segment_vessel_daily_`. In particular the segment vessel daily process uses a [window of 30 days before the date](https://github.com/GlobalFishingWatch/pipe-segment/blob/master/assets/segment_vessel_daily.sql.j2#L33) to do the calculations (`30` is parameterized).
Following the example, if we only have the shard `segment_identitiy_daily_20220101` then, the table `segment_vessel_daily_` for `2022-01-01` would request for a `segment_identity_daily_` in period `[30 days before 2022-01-01, 2022-01-01]` and the `segment_identitiy_daily_20220101` would be included, so the process will generate the results for `2022-01-01`. Then the same for `2022-01-02`.. till the 30 days didn't cover the table `segment_identitiy_daily_20220101`, example `2022-01-31` and onward, that is where the issue occurs.

To fix it, the write of the segment identity daily table was edited having priority in:
- if exists last_timestamp, use it
- then if exists first_timestamp and not last_timestamp use the end of the period to run.
- if not the start of the period to run.


Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-946