### PR TITLE
Fixed write of the segment_identity_daily_ table when is in backfill mode

### DIFF
--- a/pipe_segment/segment_identity/pipeline.py
+++ b/pipe_segment/segment_identity/pipeline.py
@@ -290,11 +290,12 @@ class SegmentIdentityPipeline:
 
     @property
     def dest_segment_identity(self):
-        from_ts, _ = self.date_range
+        from_ts, to_ts = self.date_range
         return write_sink(
             self.options.dest_segment_identity,
             self.dest_segment_identity_schema,
             timezoneToDatetime(from_ts),
+            timezoneToDatetime(to_ts),
             "Daily segments identity processed in segment step.",
         )
 

--- a/pipe_segment/segment_identity/transforms.py
+++ b/pipe_segment/segment_identity/transforms.py
@@ -127,13 +127,16 @@ BQ_PARAMS = {
 }
 
 
-def write_sink(sink_table, schema, from_dt, description):
+def write_sink(sink_table, schema, from_dt, to_dt, description):
     sink_table = sink_table.replace("bq://", "")
     bq_params_cp = dict(BQ_PARAMS)
     bq_params_cp["destinationTableProperties"]["description"] = description
 
     def compute_table(message):
-        table_suffix = from_dt.strftime("%Y%m%d")
+        # due this is for counting identity data
+        # if no last_timestamp, save in at the end of the boundary to_dt if has first_timestamp, if not at the start.
+        separator_ts=(message['last_timestamp'] if message['last_timestamp'] else (to_dt if message['first_timestamp'] else from_dt))
+        table_suffix = separator_ts.strftime("%Y%m%d")
         return "{}{}".format(sink_table, table_suffix)
 
     return beam.io.WriteToBigQuery(


### PR DESCRIPTION
The `segment_identity_daily_` table should be build following the steps:
1. Read the segments
2. Summarize the identifiers.
3. Write the segment identities per day.

In the last step, It occurs when running in a non-daily mode schedule interval, the process stores only one shard having all the summary of identities in it, in particular, right now is [the beginning of the date range](https://github.com/GlobalFishingWatch/pipe-segment/blob/jenn_fix_sat_timing/pipe_segment/segment_identity/transforms.py#L136). Ex: if back-fill period is `[2022-01-01, 2022-03-01]` then the process outputs the table `segment_identitiy_daily_20220101` with only one shard.
Later, it generates issues when trying to build the `segment_vessel_daily_`. In particular the segment vessel daily process uses a [window of 30 days before the date](https://github.com/GlobalFishingWatch/pipe-segment/blob/jenn_fix_sat_timing/assets/segment_vessel_daily.sql.j2#L33) to do the calculations (`30` is parameterized).
Following the example, if we only have the shard `segment_identitiy_daily_20220101` then, the process `segment_vessel_daily` for `2022-01-01` would request for all `segment_identity_daily_*` in period `[30 days before 2022-01-01, 2022-01-01]` and the `segment_identitiy_daily_20220101` would be included, so the process will generate the results for `2022-01-01`. Then the same for `2022-01-02`, etc.. till the 30 days where the period don't cover the table `segment_identitiy_daily_20220101`, example `2022-01-31` and onward, that is where the issue occurs.

To fix it, the write of the segment identity daily table was edited having priority in:
- if exists `last_timestamp`, use it. Because it is a summarizing of data, last_timestamp is when it ends the count.
- then if exists `first_timestamp` and not `last_timestamp` use the end of the period to run. Choose end of the period, because there is still more counts to do after the date range.
- if not presence of `last_timestamp` or `first_timestamp`, then use the start of the period to run.

I did a run with this fix for pipe 3 (`pipe_ais_test_20220802_backfill_internal`), but comparing to the previous run (`pipe_ais_test_20220801_backfill_internal`) the shard is still only one. This was because messages have no presence of `last_timestamp` or `first_timestamp` so they are stored at the start of the period to run.
However when I have to back-fill Mexico last week, it has lots of msgs with presence of last_timestamp or first_timestamp, I could notice the difference. In Mexico, one back-fill period was `[2012-01-01,2012-12-03]` so the only shard for segment identity was `segment_identity_daily_20120101`. Having only one shard affect the segment vessel identity process (img attached, only look the period `[2012-01-01,2012-12-04]`).

```segment as (
  SELECT
    *
  FROM
    `pipe_mexico_adhoc_v20220722.segment_identity_daily_*`
  WHERE
   _TABLE_SUFFIX between YYYYMMDD(windowStart()) AND YYYYMMDD(processDate())
)
-- 20111203, 20120101 it looks 30 days behind, segment_identity_daily_20120101 is inside the boundaries.
-- 20120102, 20120131 it looks 30 days behind, segment_identity_daily_20120101 is outside the boundaries.
```
After fix was applied the table segment_vessel_daily_ changed (see second img attached)
![image](https://user-images.githubusercontent.com/432563/182648093-3fe5667b-2a5a-4222-88ce-b8f98be37093.png)
![image](https://user-images.githubusercontent.com/432563/182648130-292f7725-0fa1-4469-8e1a-377bee78552b.png)
