### PR TITLE
Properly aggregate cumulative identities in segments

### DIFF
--- a/pipe_segment/pipeline.py
+++ b/pipe_segment/pipeline.py
@@ -21,6 +21,7 @@ from pipe_segment.transform.tag_with_fragid_and_date import \
     TagWithFragIdAndDate
 from pipe_segment.transform.tag_with_seg_id import TagWithSegId
 from pipe_segment.transform.write_date_sharded import WriteDateSharded
+from pipe_segment.transform.clean_segments import CleanSegments
 
 from .tools import as_timestamp, datetimeFromTimestamp
 
@@ -170,6 +171,7 @@ class SegmentPipeline:
             | "AddSegidKey" >> beam.Map(lambda x: (x["seg_id"], x))
             | "GroupBySegId" >> beam.GroupByKey()
             | "AddCumulativeData" >> CreateSegments()
+            | "AggregateCumulativeData" >> CleanSegments()
             | "FilterSegsToDateRange"
             >> beam.Filter(
                 lambda x: start_date <= timestamp_to_date(x["timestamp"]) <= end_date

--- a/pipe_segment/transform/clean_segments.py
+++ b/pipe_segment/transform/clean_segments.py
@@ -1,0 +1,46 @@
+import logging
+
+from apache_beam import FlatMap, PTransform
+from .util import swap_null, convert_idents
+
+
+class CleanSegments(PTransform):
+
+    def aggregate_cumulative_fields(self, seg):
+        '''
+        Combines identical entries in cumulative fields 
+        (i.e. cumulative_identities) with different
+        counts into a single entry with the counts summed together. 
+        Multiple entries for the same identity can happen when 
+        the segmenter is run into multiple time chunks (i.e. monthly).
+
+        Args:
+            seg: current segment in iterator
+
+        Returns:
+            Segment with only one entry per identity or destination
+            in cumulative fields.
+        '''
+        cumulative_idents = {}
+        cumulative_dests = {}
+
+        for ident in seg["cumulative_identities"]:
+            ident = ident.copy()
+            ident_cnt = ident.pop("count")
+            key = tuple([(k, str(swap_null(v))) for (k, v) in sorted(ident.items())])
+            cumulative_idents[key] = cumulative_idents.get(key, 0) + ident_cnt
+
+        for dest in seg["cumulative_destinations"]:
+            dest = dest.copy()
+            dest_cnt = dest.pop("count")
+            key = tuple([(k, str(swap_null(v))) for (k, v) in sorted(dest.items())])
+            cumulative_dests[key] = cumulative_dests.get(key, 0) + dest_cnt
+
+        seg_clean = seg.copy()
+        seg_clean["cumulative_identities"] = convert_idents(cumulative_idents)
+        seg_clean["cumulative_destinations"] = convert_idents(cumulative_dests)
+
+        yield seg_clean
+
+    def expand(self, pcoll):
+        return pcoll | FlatMap(self.aggregate_cumulative_fields)

--- a/pipe_segment/transform/create_segments.py
+++ b/pipe_segment/transform/create_segments.py
@@ -2,24 +2,10 @@ import logging
 
 from apache_beam import FlatMap, PTransform
 
-from .util import by_day
+from .util import by_day, swap_null, idents2dict, convert_idents
 
 logger = logging.getLogger(__file__)
 logger.setLevel(logging.DEBUG)
-
-
-def idents2dict(key, cnt):
-    d = {}
-    for (id_key, id_val) in key:
-        if id_val == 'null':
-            id_val = None
-        d[id_key] = id_val
-    d["count"] = cnt
-    return d
-
-
-def convert_idents(d: dict):
-    return [idents2dict(key, cnt) for (key, cnt) in d.items()]
 
 
 class CreateSegments(PTransform):
@@ -30,11 +16,6 @@ class CreateSegments(PTransform):
         cumulative_msgs = 0
         cumulative_idents = {}
         cumulative_dests = {}
-
-        def swap_null(val):
-            if val is None:
-                val = 'null'
-            return val
 
         for _, daily_frags in by_day(frags):
             daily_msgs = 0
@@ -49,14 +30,14 @@ class CreateSegments(PTransform):
                 for ident in x["identities"]:
                     ident = ident.copy()
                     ident_cnt = ident.pop("count")
-                    key = tuple([(k, swap_null(v)) for (k, v) in ident.items()])
+                    key = tuple([(k, str(swap_null(v))) for (k, v) in ident.items()])
                     daily_idents[key] = daily_idents.get(key, 0) + ident_cnt
                     cumulative_idents[key] = cumulative_idents.get(key, 0) + ident_cnt
 
                 for dest in x["destinations"]:
                     dest = dest.copy()
                     dest_cnt = dest.pop("count")
-                    key = tuple([(k, swap_null(v)) for (k, v) in dest.items()])
+                    key = tuple([(k, str(swap_null(v))) for (k, v) in dest.items()])
                     daily_dests[key] = daily_dests.get(key, 0) + dest_cnt
                     cumulative_dests[key] = cumulative_dests.get(key, 0) + dest_cnt
 

--- a/pipe_segment/transform/util.py
+++ b/pipe_segment/transform/util.py
@@ -15,3 +15,20 @@ def by_day(items, key="timestamp"):
         current.append(x)
     assert len(current) > 0
     yield day, current
+
+def swap_null(val):
+    if val is None:
+        val = 'null'
+    return val
+    
+def idents2dict(key, cnt):
+    d = {}
+    for (id_key, id_val) in key:
+        if id_val == 'null':
+            id_val = None
+        d[id_key] = id_val
+    d["count"] = cnt
+    return d
+
+def convert_idents(d: dict):
+    return [idents2dict(key, cnt) for (key, cnt) in d.items()]


### PR DESCRIPTION
* Keys used to assign cumulative identities have the following changes:
    * null are changed to 'null' for key assignment then back again for writing out
    * all values casted to string so that they will match the cumulative identities of segments that are read in, which come in as all strings
* New PTransform created - CleanSegments() - that does the aggregation of cumulative identities. This step comes right after AddCumulativeIdentities in the pipeline.
* Some functions shared by CreateSegments and CleanSegments are moved to util.py