### PR TITLE
segment_identity_daily fixes

### DIFF
--- a/pipe_segment/segment_identity/transforms.py
+++ b/pipe_segment/segment_identity/transforms.py
@@ -65,7 +65,7 @@ def summarize_identifiers(segment):
         "msg_count": segment.get("message_count"),
         # We approximate positional message counts by summing all the counts
         # from all the different transponder values we collected in the segment.
-        "pos_count": sum(map(extract_count, transponders)),
+        "pos_count": segment.get("daily_msg_count"),
         # We approximate identity message count by summing all the counts from
         # the atomic identity messages we collected in the segment.
         "ident_count": sum(counts),

--- a/pipe_segment/segment_identity/transforms.py
+++ b/pipe_segment/segment_identity/transforms.py
@@ -44,13 +44,15 @@ def extract(identities, key):
             mapping[value] += ident["count"]
     return [{"value": k, "count": v} for (k, v) in mapping.items()]
 
-
 def summarize_identifiers(segment):
     identities = segment["daily_identities"]
+    counts = [ident["count"] for ident in identities]
     transponders = extract(identities, "transponder_type")
     shipnames = extract(identities, "shipname")
     callsigns = extract(identities, "callsign")
     imos = extract(identities, "imo")
+    lengths = extract(identities, "length")
+    widths = extract(identities, "width")
 
     return {
         "seg_id": segment.get("seg_id"),
@@ -62,11 +64,11 @@ def summarize_identifiers(segment):
         "last_pos_timestamp": segment.get("last_msg_of_day_timestamp"),
         "msg_count": segment.get("message_count"),
         # We approximate positional message counts by summing all the counts
-        # from all the diferent transponder values we collected in the segment.
+        # from all the different transponder values we collected in the segment.
         "pos_count": sum(map(extract_count, transponders)),
         # We approximate identity message count by summing all the counts from
-        # all the different shipname values we collected.
-        "ident_count": sum(map(extract_count, shipnames)),
+        # the atomic identity messages we collected in the segment.
+        "ident_count": sum(counts),
         "shipname": shipnames or None,
         "callsign": callsigns or None,
         "imo": imos or None,
@@ -74,8 +76,8 @@ def summarize_identifiers(segment):
         "n_callsign": normalize_counted_array(normalize_callsign, callsigns) or None,
         "n_imo": normalize_counted_array(normalize_imo, imos) or None,
         "shiptype": None,
-        "length": None,
-        "width": None,
+        "length": lengths or None,
+        "width": widths or None,
         "noise": False,
     }
 


### PR DESCRIPTION
* Pulled out daily_identities.counts and used that for ident_count instead of counting only messages with non-null shipnames
* Added lengths and widths

Two questions:
* why is noise always False?
* why do we not pass `shiptype` into `segments` and then onto `segment_identity_daily`?