### PR TITLE
Small segment_vessel_daily fix

### DIFF
--- a/assets/util.sql.j2
+++ b/assets/util.sql.j2
@@ -28,7 +28,7 @@ CREATE TEMP FUNCTION mostCommon(
    FROM (
      SELECT as struct r.value as value, sum(r.count) as count
      FROM unnest(arr) as r group by r.value
-     ORDER BY count, value DESC
+     ORDER BY count DESC, value
      LIMIT 1
      )
    )


### PR DESCRIPTION
Fixed a bug I introduced while trying to break ties in mostCommon() in util.sql.j2. It was putting in the least common value when more than one value was present.