### PR TITLE
Try to reduce shuffle

### DIFF
--- a/pipe_segment/options/segment.py
+++ b/pipe_segment/options/segment.py
@@ -112,3 +112,8 @@ class SegmentOptions(PipelineOptions):
             "testing purposes and if tempted to use for production, more work should be done "
             "so that the data is pruned on the way in.",
         )
+        optional.add_argument(
+            "--bins_per_day",
+            default=4,
+            help="Amount of containers per day to tag fragments and messages.",
+        )

--- a/pipe_segment/pipeline.py
+++ b/pipe_segment/pipeline.py
@@ -157,7 +157,7 @@ class SegmentPipeline:
             | CreateSegmentMap(self.merge_params)
         )
 
-        bins_per_day = 24
+        bins_per_day = 4
         msg_segmap = segmap_src | TagWithFragIdAndTimeBin(
             start_date, end_date, bins_per_day
         )

--- a/pipe_segment/pipeline.py
+++ b/pipe_segment/pipeline.py
@@ -157,7 +157,7 @@ class SegmentPipeline:
             | CreateSegmentMap(self.merge_params)
         )
 
-        bins_per_day = 48
+        bins_per_day = 24
         msg_segmap = segmap_src | TagWithFragIdAndTimeBin(
             start_date, end_date, bins_per_day
         )

--- a/pipe_segment/pipeline.py
+++ b/pipe_segment/pipeline.py
@@ -157,7 +157,7 @@ class SegmentPipeline:
             | CreateSegmentMap(self.merge_params)
         )
 
-        bins_per_day = 4
+        bins_per_day = self.options.bins_per_day
         msg_segmap = segmap_src | TagWithFragIdAndTimeBin(
             start_date, end_date, bins_per_day
         )

--- a/pipe_segment/transform/tag_with_fragid_and_timebin.py
+++ b/pipe_segment/transform/tag_with_fragid_and_timebin.py
@@ -14,14 +14,9 @@ class TagWithFragIdAndTimeBin(PTransform):
         self.bins_per_day = bins_per_day
 
     def tag_frags(self, x):
-        frag_id = x["frag_id"]
-        date_str = frag_id.split("T")[0].split("-", 1)[1]
-        assert len(date_str) == 10
-        start_date_str = f"{self.start_date:%Y-%m-%d}"
-        end_date_str = f"{self.end_date:%Y-%m-%d}"
-        if start_date_str <= date_str <= end_date_str:
-            for bin in range(self.bins_per_day):
-                yield ((x["frag_id"], str(date), bin), x)
+        if self.start_date <= x["date"] <= self.end_date:
+            for sub_bin in range(self.bins_per_day):
+                yield ((x["frag_id"], x["date"], sub_bin), x)
 
     def expand(self, xs):
         return xs | FlatMap(self.tag_frags)

--- a/pipe_segment/transform/tag_with_fragid_and_timebin.py
+++ b/pipe_segment/transform/tag_with_fragid_and_timebin.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import date, timedelta
+from datetime import date
 
 from apache_beam import FlatMap, PTransform
 
@@ -14,11 +14,14 @@ class TagWithFragIdAndTimeBin(PTransform):
         self.bins_per_day = bins_per_day
 
     def tag_frags(self, x):
-        date = self.start_date
-        while date <= self.end_date:
+        frag_id = x["frag_id"]
+        date_str = frag_id.split("T")[0].split("-", 1)[1]
+        assert len(date_str) == 10
+        start_date_str = f"{self.start_date:%Y-%m-%d}"
+        end_date_str = f"{self.end_date:%Y-%m-%d}"
+        if start_date_str <= date_str <= end_date_str:
             for bin in range(self.bins_per_day):
                 yield ((x["frag_id"], str(date), bin), x)
-            date += timedelta(days=1)
 
     def expand(self, xs):
         return xs | FlatMap(self.tag_frags)

--- a/pipe_segment/transform/tag_with_fragid_and_timebin.py
+++ b/pipe_segment/transform/tag_with_fragid_and_timebin.py
@@ -16,7 +16,7 @@ class TagWithFragIdAndTimeBin(PTransform):
     def tag_frags(self, x):
         if self.start_date <= x["date"] <= self.end_date:
             for sub_bin in range(self.bins_per_day):
-                yield ((x["frag_id"], x["date"], sub_bin), x)
+                yield ((x["frag_id"], str(x["date"]), sub_bin), x)
 
     def expand(self, xs):
         return xs | FlatMap(self.tag_frags)


### PR DESCRIPTION
I suspect that the trick I used to reduce instance memory usage is causing excessive shuffle usage. Fix this by pruning
the dictionary we use to make the join to only have entries on the correct days.