### PR TITLE
Fix fragment compare binsperday increased

### DIFF
--- a/pipe_segment/options/segment.py
+++ b/pipe_segment/options/segment.py
@@ -112,3 +112,8 @@ class SegmentOptions(PipelineOptions):
             "testing purposes and if tempted to use for production, more work should be done "
             "so that the data is pruned on the way in.",
         )
+        optional.add_argument(
+            "--bins_per_day",
+            default=4,
+            help="Amount of containers per day to tag fragments and messages.",
+        )

--- a/pipe_segment/pipeline.py
+++ b/pipe_segment/pipeline.py
@@ -157,7 +157,7 @@ class SegmentPipeline:
             | CreateSegmentMap(self.merge_params)
         )
 
-        bins_per_day = 4
+        bins_per_day = 24
         msg_segmap = segmap_src | TagWithFragIdAndTimeBin(
             start_date, end_date, bins_per_day
         )

--- a/pipe_segment/pipeline.py
+++ b/pipe_segment/pipeline.py
@@ -157,7 +157,7 @@ class SegmentPipeline:
             | CreateSegmentMap(self.merge_params)
         )
 
-        bins_per_day = 48
+        bins_per_day = self.options.bins_per_day
         msg_segmap = segmap_src | TagWithFragIdAndTimeBin(
             start_date, end_date, bins_per_day
         )

--- a/pipe_segment/pipeline.py
+++ b/pipe_segment/pipeline.py
@@ -157,7 +157,7 @@ class SegmentPipeline:
             | CreateSegmentMap(self.merge_params)
         )
 
-        bins_per_day = 24
+        bins_per_day = 48
         msg_segmap = segmap_src | TagWithFragIdAndTimeBin(
             start_date, end_date, bins_per_day
         )

--- a/pipe_segment/transform/fragment.py
+++ b/pipe_segment/transform/fragment.py
@@ -16,6 +16,10 @@ def none_to_inf(x):
     return math.inf if (x is None) else x
 
 
+def none_to_blank(x):
+    return "" if (x is None) else x
+
+
 def make_schema():
     schema = {"fields": []}
 
@@ -50,10 +54,18 @@ def make_schema():
             fields=[dict(name="count", type="INTEGER", mode="NULLABLE")],
         )
         for fld_name in value_type._fields:
-            field["fields"].append(dict(name=fld_name, type=type_map.get(fld_name, "STRING"), mode="NULLABLE"))
+            field["fields"].append(
+                dict(
+                    name=fld_name,
+                    type=type_map.get(fld_name, "STRING"),
+                    mode="NULLABLE",
+                )
+            )
         schema["fields"].append(field)
 
-    add_ident_field("identities", Identity, type_map={"length" : "FLOAT", "width" : "FLOAT"})
+    add_ident_field(
+        "identities", Identity, type_map={"length": "FLOAT", "width": "FLOAT"}
+    )
     add_ident_field("destinations", Destination, type_map={})
 
     return schema
@@ -110,18 +122,18 @@ class Fragment(PTransform):
                 none_to_inf(x["speed"]),
                 none_to_inf(x["course"]),
                 none_to_inf(x["heading"]),
-                none_to_inf(x["destination"]),
+                none_to_blank(x["destination"]),
                 none_to_inf(x["length"]),
                 none_to_inf(x["width"]),
-                none_to_inf(x["shiptype"]),
+                none_to_blank(x["shiptype"]),
                 none_to_inf(x["status"]),
                 none_to_inf(x["source"]),
                 none_to_inf(x["type"]),
-                none_to_inf(x["shipname"]),
-                none_to_inf(x["callsign"]),
-                none_to_inf(x["imo"]),
-                none_to_inf(x["receiver_type"]),
-                none_to_inf(x["receiver"]),
+                none_to_blank(x["shipname"]),
+                none_to_blank(x["callsign"]),
+                none_to_blank(x["imo"]),
+                none_to_blank(x["receiver_type"]),
+                none_to_blank(x["receiver"]),
             )
         )
         for key, value in self._fragmenter.fragment(messages):

--- a/pipe_segment/transform/tag_with_fragid_and_timebin.py
+++ b/pipe_segment/transform/tag_with_fragid_and_timebin.py
@@ -1,22 +1,23 @@
-from datetime import timedelta, date
 import logging
+from datetime import date, timedelta
 
-from apache_beam import PTransform
-from apache_beam import FlatMap
+from apache_beam import FlatMap, PTransform
 
 logger = logging.getLogger(__file__)
 logger.setLevel(logging.DEBUG)
 
 
-class TagWithFragIdAndDate(PTransform):
-    def __init__(self, start_date: date, end_date: date):
+class TagWithFragIdAndTimeBin(PTransform):
+    def __init__(self, start_date: date, end_date: date, bins_per_days: int):
         self.start_date = start_date
         self.end_date = end_date
+        self.bins_per_day = bins_per_days
 
     def tag_frags(self, x):
         date = self.start_date
         while date <= self.end_date:
-            yield ((x["frag_id"], str(date)), x)
+            for bin in range(self.bins_per_days):
+                yield ((x["frag_id"], str(date), bin), x)
             date += timedelta(days=1)
 
     def expand(self, xs):

--- a/pipe_segment/transform/tag_with_fragid_and_timebin.py
+++ b/pipe_segment/transform/tag_with_fragid_and_timebin.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import date, timedelta
+from datetime import date
 
 from apache_beam import FlatMap, PTransform
 
@@ -14,11 +14,9 @@ class TagWithFragIdAndTimeBin(PTransform):
         self.bins_per_day = bins_per_day
 
     def tag_frags(self, x):
-        date = self.start_date
-        while date <= self.end_date:
-            for bin in range(self.bins_per_day):
-                yield ((x["frag_id"], str(date), bin), x)
-            date += timedelta(days=1)
+        if self.start_date <= x["date"] <= self.end_date:
+            for sub_bin in range(self.bins_per_day):
+                yield ((x["frag_id"], str(x["date"]), sub_bin), x)
 
     def expand(self, xs):
         return xs | FlatMap(self.tag_frags)

--- a/pipe_segment/transform/tag_with_fragid_and_timebin.py
+++ b/pipe_segment/transform/tag_with_fragid_and_timebin.py
@@ -8,15 +8,15 @@ logger.setLevel(logging.DEBUG)
 
 
 class TagWithFragIdAndTimeBin(PTransform):
-    def __init__(self, start_date: date, end_date: date, bins_per_days: int):
+    def __init__(self, start_date: date, end_date: date, bins_per_day: int):
         self.start_date = start_date
         self.end_date = end_date
-        self.bins_per_day = bins_per_days
+        self.bins_per_day = bins_per_day
 
     def tag_frags(self, x):
         date = self.start_date
         while date <= self.end_date:
-            for bin in range(self.bins_per_days):
+            for bin in range(self.bins_per_day):
                 yield ((x["frag_id"], str(date), bin), x)
             date += timedelta(days=1)
 


### PR DESCRIPTION
* subdivide tags when labelling messages, using `bins_per_day`.
* convert Nones to blanks for string variables, instead of to inf as before.
* all related in PR https://github.com/GlobalFishingWatch/pipe-segment/pull/141