### PR TITLE
split read fragments up by year to try to prevent a timeout

### DIFF
--- a/pipe_segment/transform/read_fragments.py
+++ b/pipe_segment/transform/read_fragments.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime, timedelta
 
 import apache_beam as beam
 from google.api_core.exceptions import BadRequest
@@ -15,60 +16,71 @@ class ReadFragments(beam.PTransform):
         self.end_date = end_date
         self.create_if_missing = create_if_missing
 
-    def table_present(self):
+    def first_table_date(self):
         client = bigquery.Client(self.project)
-        query = f"""SELECT COUNT(*) cnt FROM `{self.source}*`
-                     WHERE {self.query_condition}"""
+        condition = self.query_condition(self.start_date, self.end_date)
+        query = f"""SELECT MIN(_TABLE_SUFFIX) min_suffix FROM `{self.source}*`
+                     WHERE {condition}"""
         logging.info(f"QUERY:\n{query}")
         request = client.query(query)
         try:
             [row] = request.result()
-            if row.cnt == 0:
-                return False
         except BadRequest as err:
-            return False
+            return None
             logging.info(
                 f"Could not query existing table. Ignore if this is first run: {err}"
             )
         else:
-            return True
+            return datetime.strptime(row.min_suffix, "%Y%m%d").date()
 
-    @property
-    def query_condition(self):
-        if self.start_date is None:
-            return f'''_TABLE_SUFFIX <= "{self.end_date:%Y%m%d}"'''
+    def query_condition(self, start_date, end_date):
+        if start_date is None:
+            return f'''_TABLE_SUFFIX <= "{end_date:%Y%m%d}"'''
         else:
-            return '''_TABLE_SUFFIX BETWEEN "{self.start_date:%Y%m%d}"
-                         AND "{self.end_date:%Y%m%d}"'''
+            return f'''_TABLE_SUFFIX BETWEEN "{start_date:%Y%m%d}"
+                         AND "{end_date:%Y%m%d}"'''
 
-    @property
-    def query(self):
-        query = f"""
-        SELECT *
-        FROM (
-            SELECT
-              CAST(UNIX_MICROS(timestamp) AS FLOAT64) / 1000000  AS timestamp,
-              CAST(UNIX_MICROS(first_msg_timestamp) AS FLOAT64) / 1000000
-                    AS first_msg_timestamp,
-              CAST(UNIX_MICROS(last_msg_timestamp) AS FLOAT64) / 1000000
-                    AS last_msg_timestamp,
-                * except (
-                        timestamp, 
-                        first_msg_timestamp, 
-                        last_msg_timestamp
-                    )
-            FROM `{self.source}*`
-            WHERE {self.query_condition}
-            ORDER BY ssvid, timestamp
-        )
-        """
-        logging.info(f"READ FRAGMENTS QUERY:\n{query}")
-        return query
+    def make_queries(self, first_table_date):
+        if self.start_date is None:
+            start_date = first_table_date
+        else:
+            start_date = max(first_table_date, self.start_date)
+        while start_date <= self.end_date:
+            next_start_date = start_date + timedelta(days=365)
+            end_date = next_start_date - timedelta(days=1)
+            condition = self.query_condition(start_date, end_date)
+            query = f"""
+            SELECT *
+            FROM (
+                SELECT
+                  CAST(UNIX_MICROS(timestamp) AS FLOAT64) / 1000000  AS timestamp,
+                  CAST(UNIX_MICROS(first_msg_timestamp) AS FLOAT64) / 1000000
+                        AS first_msg_timestamp,
+                  CAST(UNIX_MICROS(last_msg_timestamp) AS FLOAT64) / 1000000
+                        AS last_msg_timestamp,
+                    * except (
+                            timestamp, 
+                            first_msg_timestamp, 
+                            last_msg_timestamp
+                        )
+                FROM `{self.source}*`
+                WHERE {condition}
+                ORDER BY ssvid, timestamp
+            )
+            """
+            logging.info(f"Emitting read fragments query:\n{query}")
+            yield query
+            start_date = next_start_date
 
     def expand(self, pcoll):
-        if self.create_if_missing and not self.table_present():
+        first_table_date = self.first_table_date()
+        if self.create_if_missing and first_table_date is None:
             return pcoll | beam.Create([])
         else:
-            return pcoll | beam.io.ReadFromBigQuery(
-                query=self.query, use_standard_sql=True
-            )
+            queries = [
+                pcoll
+                | f"ReadFragments{i}"
+                >> beam.io.ReadFromBigQuery(query=query, use_standard_sql=True)
+                for i, query in enumerate(self.make_queries(first_table_date))
+            ]
+            return queries | beam.Flatten()


### PR DESCRIPTION
Fix made by Tim(@bitsofbits), creating a PR for it.
Issue: the segment query for 2020 was timing out.

- The fix splits the fragments query
- The first run of this is here [smoketestsegmenter2](https://console.cloud.google.com/dataflow/jobs/us-central1/2022-10-31_13_47_18-7475996986273935764;step=ReadFragments;mainTab=JOB_GRAPH;logsSeverity=ERROR;graphView=0?project=world-fishing-827).

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-1043