### PR TITLE
Switch the satellite offsets table from daily sharded to partitioned

### DIFF
--- a/pipe_segment/__main__.py
+++ b/pipe_segment/__main__.py
@@ -1,10 +1,11 @@
 import sys
-
-
+from apache_beam.options.pipeline_options import GoogleCloudOptions
 from pipe_segment.options.segment import SegmentOptions
 from pipe_segment.options.validate_options import validate_options
 from pipe_segment.options.logging_options import LoggingOptions
+from pipe_segment.transform.satellite_offsets import remove_satellite_offsets_content
 from pipe_segment import pipeline
+
 
 
 def run(args):
@@ -15,6 +16,10 @@ def run(args):
     )
 
     options.view_as(LoggingOptions).configure_logging()
+
+    seg_options = options.view_as(SegmentOptions)
+    gcloud_options = options.view_as(GoogleCloudOptions)
+    remove_satellite_offsets_content(seg_options.sat_offset_dest, seg_options.date_range, gcloud_options.labels, gcloud_options.project)
 
     return pipeline.run(options)
 

--- a/pipe_segment/pipeline.py
+++ b/pipe_segment/pipeline.py
@@ -121,12 +121,6 @@ class SegmentPipeline:
                             }
                         }
                     )
-                    # >> WriteDateSharded(
-                    #     self.options.sat_offset_dest,
-                    #     self.cloud_options.project,
-                    #     SatelliteOffsets.schema,
-                    #     key="hour",
-                    # )
                 )
 
             messages = messages | FilterBadSatelliteTimes(

--- a/pipe_segment/transform/satellite_offsets.py
+++ b/pipe_segment/transform/satellite_offsets.py
@@ -4,8 +4,55 @@ from jinja2 import Template
 
 import apache_beam as beam
 import apache_beam.io.gcp.bigquery
+import logging, functools
 from apache_beam import PTransform, io
+from google.api_core.exceptions import (NotFound, BadRequest)
+from google.cloud import bigquery
 
+
+def remove_satellite_offsets_content(destination_table:str, date_range:str, labels_list: list, project:str):
+    """
+    The satellite offset table is now a partitioned table. It removes the content of the satellite offeset table for the period of date range to let the DF job generate the new data.
+    :param destination_table: The destination table from where to delete the content.
+    :type destination_table: str.
+    :param date_range: The date start and end to delete the content.
+    :type date_range: str.
+    :param labels_list: The labels to be assigned when interact with BQ.
+    :type labels_list: list.
+    :param project: The google cloud project name.
+    :type project: str.
+    """
+    client = bigquery.Client(project)
+    destination_table_ds, destination_table_tb = destination_table.split('.')
+    destination_dataset_ref = bigquery.DatasetReference(client.project, destination_table_ds)
+    destination_table_ref = destination_dataset_ref.table(destination_table_tb)
+    date_from, date_to = list(map(lambda x:x.strip(), date_range.split(',')))
+    labels = functools.reduce(lambda x,y: dict(x,**{y.split('=')[0]: y.split('=')[1]}), labels_list, dict())
+
+    try:
+        table = client.get_table(destination_table_ref) #API request
+        logging.info(f'Ensures the table [{table}] exists.')
+        #deletes the content
+        query_job = client.query(
+            f"""
+               DELETE FROM `{ destination_table }`
+               WHERE date(hour) BETWEEN '{date_from}' AND '{date_to}'
+            """,
+            bigquery.QueryJobConfig(
+                use_query_cache=False,
+                use_legacy_sql=False,
+                labels=labels,
+            )
+        )
+        logging.info(f'Delete Job {query_job.job_id} is currently in state {query_job.state}')
+        result = query_job.result()
+        logging.info(f'Date range [{date_from},{date_to}] cleaned in table {destination_table}: {result}')
+
+    except NotFound as nferr:
+        logging.warn(f'Table {destination_table} NOT FOUND. We can go on.')
+
+    except BadRequest as err:
+        logging.error(f'Bad request received {err}.')
 
 def make_schema():
     schema = {"fields": []}


### PR DESCRIPTION
The current satellite offset table which is generated in the segment step in saved in daily sharded tables while later in the research step, the table is used for lookup in the generation of the:
- research_messages_daily
- research_messages_only_spire_daily
- research_segment_daily
- research_ids_daily
- research_stats
And we moved particularly to partitioned to have it well handled.
Partitioned monthly by `hour` field and clustered by same field, also added the require filter parameter to limit the lookup.

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-1270