### PR TITLE
Fixing error in reading fragments when want to re-runs segment with already present fragment_ tables.

### DIFF
--- a/pipe_segment/transform/read_fragments.py
+++ b/pipe_segment/transform/read_fragments.py
@@ -26,12 +26,12 @@ class ReadFragments(beam.PTransform):
         try:
             [row] = request.result()
         except BadRequest as err:
-            return None
             logging.info(
                 f"Could not query existing table. Ignore if this is first run: {err}"
             )
+            return None
         else:
-            return datetime.strptime(row.min_suffix, "%Y%m%d").date()
+            return datetime.strptime(row.min_suffix, "%Y%m%d").date() if row.min_suffix != None else None
 
     def query_condition(self, start_date, end_date):
         if start_date is None:


### PR DESCRIPTION
The segment task when runs from scratch reads the fragments, and there are no `fragments_` tables under the dataset so the first_table_date function returns `None` and the pipeline starts well, creating an empty dict.

But when there are `fragments_` tables and if we want to re-run from the start, we found the [first_table_date](https://github.com/GlobalFishingWatch/pipe-segment/blob/release-v4/pipe_segment/transform/read_fragments.py#L19) function queries the previous date (ex if we started from `2020-01-01`, previous is `2019-12-31`), and the `fragment_` for that previous day does not exists, so the query returns `null` and throw this error:

```
[2023-04-18, 18:55:46 UTC] {pod_manager.py:228} INFO - INFO:root:QUERY:
[2023-04-18, 18:55:46 UTC] {pod_manager.py:228} INFO - SELECT MIN(_TABLE_SUFFIX) min_suffix FROM `pipe_ais_test_20230418_daily_internal.fragments_*`
[2023-04-18, 18:55:46 UTC] {pod_manager.py:228} INFO -                      WHERE _TABLE_SUFFIX <= "20191231"
[2023-04-18, 18:55:47 UTC] {pod_manager.py:228} INFO - Traceback (most recent call last):
[2023-04-18, 18:55:47 UTC] {pod_manager.py:228} INFO -   File "/usr/local/lib/python3.7/runpy.py", line 193, in _run_module_as_main
[2023-04-18, 18:55:47 UTC] {pod_manager.py:228} INFO -     "__main__", mod_spec)
[2023-04-18, 18:55:47 UTC] {pod_manager.py:228} INFO -   File "/usr/local/lib/python3.7/runpy.py", line 85, in _run_code
[2023-04-18, 18:55:47 UTC] {pod_manager.py:228} INFO -     exec(code, run_globals)
[2023-04-18, 18:55:47 UTC] {pod_manager.py:228} INFO -   File "/opt/project/pipe_segment/__main__.py", line 28, in <module>
[2023-04-18, 18:55:47 UTC] {pod_manager.py:228} INFO -     sys.exit(run(args=sys.argv[1:]))
[2023-04-18, 18:55:47 UTC] {pod_manager.py:228} INFO -   File "/opt/project/pipe_segment/__main__.py", line 24, in run
[2023-04-18, 18:55:47 UTC] {pod_manager.py:228} INFO -     return pipeline.run(options)
[2023-04-18, 18:55:47 UTC] {pod_manager.py:228} INFO -   File "/opt/project/pipe_segment/pipeline.py", line 226, in run
[2023-04-18, 18:55:47 UTC] {pod_manager.py:228} INFO -     result = pipeline.run()
[2023-04-18, 18:55:47 UTC] {pod_manager.py:228} INFO -   File "/opt/project/pipe_segment/pipeline.py", line 220, in run
[2023-04-18, 18:55:47 UTC] {pod_manager.py:228} INFO -     return self.pipeline().run()
[2023-04-18, 18:55:47 UTC] {pod_manager.py:228} INFO -   File "/opt/project/pipe_segment/pipeline.py", line 157, in pipeline
[2023-04-18, 18:55:47 UTC] {pod_manager.py:228} INFO -     create_if_missing=True,
[2023-04-18, 18:55:47 UTC] {pod_manager.py:228} INFO -   File "/usr/local/lib/python3.7/site-packages/apache_beam/transforms/ptransform.py", line 617, in __ror__
[2023-04-18, 18:55:47 UTC] {pod_manager.py:228} INFO -     result = p.apply(self, pvalueish, label)
[2023-04-18, 18:55:47 UTC] {pod_manager.py:228} INFO -   File "/usr/local/lib/python3.7/site-packages/apache_beam/pipeline.py", line 709, in apply
[2023-04-18, 18:55:47 UTC] {pod_manager.py:228} INFO -     pvalueish_result = self.runner.apply(transform, pvalueish, self._options)
[2023-04-18, 18:55:47 UTC] {pod_manager.py:228} INFO -   File "/usr/local/lib/python3.7/site-packages/apache_beam/runners/dataflow/dataflow_runner.py", line 141, in apply
[2023-04-18, 18:55:47 UTC] {pod_manager.py:228} INFO -     return super().apply(transform, input, options)
[2023-04-18, 18:55:47 UTC] {pod_manager.py:228} INFO -   File "/usr/local/lib/python3.7/site-packages/apache_beam/runners/runner.py", line 185, in apply
[2023-04-18, 18:55:47 UTC] {pod_manager.py:228} INFO -     return m(transform, input, options)
[2023-04-18, 18:55:47 UTC] {pod_manager.py:228} INFO -   File "/usr/local/lib/python3.7/site-packages/apache_beam/runners/runner.py", line 215, in apply_PTransform
[2023-04-18, 18:55:47 UTC] {pod_manager.py:228} INFO -     return transform.expand(input)
[2023-04-18, 18:55:47 UTC] {pod_manager.py:228} INFO -   File "/opt/project/pipe_segment/transform/read_fragments.py", line 76, in expand
[2023-04-18, 18:55:47 UTC] {pod_manager.py:228} INFO -     first_table_date = self.first_table_date()
[2023-04-18, 18:55:47 UTC] {pod_manager.py:228} INFO -   File "/opt/project/pipe_segment/transform/read_fragments.py", line 34, in first_table_date
[2023-04-18, 18:55:47 UTC] {pod_manager.py:228} INFO -     return datetime.strptime(row.min_suffix, "%Y%m%d").date()
```

Tested with daily/monthly baby_pipeline.
Ex:
Already present tables:
- pipe_ais_test_20230418_daily_internal.fragment_20200101
- pipe_ais_test_20230418_daily_internal.fragment_20200102
Re-running from start, the [first_table_date](https://github.com/GlobalFishingWatch/pipe-segment/blob/release-v4/pipe_segment/transform/read_fragments.py#L19) function queries:
```sql
SELECT MIN(_TABLE_SUFFIX) min_suffix FROM `pipe_ais_test_20230418_daily_internal.fragments_*` WHERE _TABLE_SUFFIX <= "20191231"
```
So, the table pipe_ais_test_20230418_daily_internal.fragment_20191231 does not exists and returns `[{"min_suffix": null}]`, later the error [here](https://github.com/GlobalFishingWatch/pipe-segment/blob/release-v4/pipe_segment/transform/read_fragments.py#L34).

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-1274