### PR TITLE
PIPELINE-1262: Fixes normalized and denormalized values missmatching on vessel info

### DIFF
--- a/pipe_segment/segment_identity/pipeline.py
+++ b/pipe_segment/segment_identity/pipeline.py
@@ -92,12 +92,6 @@ class SegmentIdentityPipeline:
                     "description": "Number of identity messages in the segment for this day. Note that some messages can contain both position and identity",
                 },
                 {
-                    "mode": "NULLABLE",
-                    "name": "noise",
-                    "type": "BOOLEAN",
-                    "description": "If true, then this is a noise segment, usually because of an invalid lat or lon value.  Messages in these segments should be filtered out",
-                },
-                {
                     "fields": [
                         {
                             "mode": "NULLABLE",
@@ -216,26 +210,6 @@ class SegmentIdentityPipeline:
                     "name": "n_imo",
                     "type": "RECORD",
                     "description": "Array of all unique valid imo numbers for this segment for this day.",
-                },
-                {
-                    "fields": [
-                        {
-                            "mode": "NULLABLE",
-                            "name": "value",
-                            "type": "STRING",
-                            "description": "Unique field value",
-                        },
-                        {
-                            "mode": "NULLABLE",
-                            "name": "count",
-                            "type": "INTEGER",
-                            "description": "Number of times the unique field value occured for this segment for this day",
-                        },
-                    ],
-                    "mode": "REPEATED",
-                    "name": "shiptype",
-                    "type": "RECORD",
-                    "description": "Array of all unique shiptypes for this segment for this day. Note that this field is already normalized in the messages",
                 },
                 {
                     "fields": [

--- a/requirements-worker.txt
+++ b/requirements-worker.txt
@@ -2,6 +2,6 @@ gpsdio-segment @ https://codeload.github.com/GlobalFishingWatch/gpsdio-segment/t
 pandas==1.3.5
 python-stdnum==1.17
 ujson==1.35
-shipdataprocess==0.6.9
+shipdataprocess==0.7.1
 jinja2==3.0.2
 

--- a/tests/test_segment_identity_daily.py
+++ b/tests/test_segment_identity_daily.py
@@ -7,196 +7,185 @@ from pipe_segment.segment_identity.transforms import summarize_identifiers
 def as_timestamp(dt):
     return parse(dt).timestamp()
 
+def build_example_segment_with_identities(daily_msg_count, daily_identities):
+    """
+    For the purposes of these tests, what we are interested in is in the daily
+    identities array and the daily message counts of the segment. This function
+    creates an example segment with everything that can come out of the
+    segmenter, but lets each test provide those two fields to setup expectations.
+    """
+    return {
+        "seg_id": "338013000-2017-07-16T19:15:55.000000Z-1",
+        "frag_id": "338013000-2017-07-20T00:27:29.000000Z-1",
+        "ssvid": "338013000",
+        "timestamp": as_timestamp("2017-07-20 00:00:00.000000 UTC"),
+        "first_msg_timestamp": as_timestamp("2017-01-01T11:00:00.00000 UTC"),
+        "last_msg_timestamp": as_timestamp("2017-01-01T11:00:00.00000 UTC"),
+        "daily_msg_count": daily_msg_count,
+        "daily_identities": daily_identities,
+        "daily_destinations": [{
+            "count": 45,
+            "destination": "FISHING GROUND"
+        }],
+        "first_timestamp": as_timestamp("2017-07-16 19:15:55.000000 UTC"),
+        "cumulative_msg_count": "931",
+        "cumulative_identities": [{
+            "count": 243,
+            "shipname": "FRIESLAND",
+            "callsign": "WDE6789",
+            "imo": "9310953",
+            "transponder_type": "AIS-A",
+            "length": "89.0",
+            "width": "14.0"
+        }, {
+            "count": 2,
+            "shipname": "FRIESLT^D I *2@  *\"",
+            "callsign": "WDE6789",
+            "imo": "9310953",
+            "transponder_type": "AIS-A",
+            "length": "505.0",
+            "width": "14.0"
+        }],
+        "cumulative_destinations": [{
+            "count": 38,
+            "destination": "SUVA FIJI"
+        }, {
+            "count": 205,
+            "destination": "FISHING GROUND"
+        }, {
+            "count": 2,
+            "destination": "BIRHIL`\"\u0026BOUND"
+        }]
+    }
+
+def expected_segment_identities(segment, **fields):
+    return {
+        "seg_id": segment.get("seg_id"),
+        "ssvid": segment.get("ssvid"),
+        "timestamp": segment.get("timestamp"),
+        "first_pos_timestamp": segment.get("first_msg_timestamp"),
+        "first_timestamp": segment.get("first_msg_timestamp"),
+        "last_pos_timestamp": segment.get("last_msg_timestamp"),
+        "last_timestamp": segment.get("last_msg_timestamp"),
+        **fields,
+    }
+
+def counted_value(value, count):
+    return {
+        "count": count,
+        "value": value,
+    }
+
 class TestSegmentIdentityDaily():
-    def test_summarize_identifiers_no_empties(self):
-        segment = {
-            "seg_id": "338013000-2017-07-16T19:15:55.000000Z-1",
-            "frag_id": "338013000-2017-07-20T00:27:29.000000Z-1",
-            "ssvid": "338013000",
-            "timestamp": as_timestamp("2017-07-20 00:00:00.000000 UTC"),
-            "daily_msg_count": 295,
-            "daily_identities": [{
-                "count": 45,
-                "shipname": "FRIESLAND",
-                "callsign": "WDE6789",
-                "imo": "9310953",
-                "transponder_type": "AIS-A",
-                "length": "89.0",
-                "width": "14.0"
-            }],
-            "daily_destinations": [{
-                "count": 45,
-                "destination": "FISHING GROUND"
-            }],
-            "first_timestamp": as_timestamp("2017-07-16 19:15:55.000000 UTC"),
-            "cumulative_msg_count": "931",
-            "cumulative_identities": [{
-                "count": 243,
-                "shipname": "FRIESLAND",
-                "callsign": "WDE6789",
-                "imo": "9310953",
-                "transponder_type": "AIS-A",
-                "length": "89.0",
-                "width": "14.0"
-            }, {
-                "count": 2,
-                "shipname": "FRIESLT^D I *2@  *\"",
-                "callsign": "WDE6789",
-                "imo": "9310953",
-                "transponder_type": "AIS-A",
-                "length": "505.0",
-                "width": "14.0"
-            }],
-            "cumulative_destinations": [{
-                "count": 38,
-                "destination": "SUVA FIJI"
-            }, {
-                "count": 205,
-                "destination": "FISHING GROUND"
-            }, {
-                "count": 2,
-                "destination": "BIRHIL`\"\u0026BOUND"
-            }]
-        }
+    def test_summarize_identifiers_no_noise(self):
+        segment = build_example_segment_with_identities(
+            daily_msg_count=295,
+            daily_identities=[
+                {
+                    "count": 45,
+                    "shipname": "FRIESLAND ONE",
+                    "callsign": "0WDE6789",
+                    "imo": "9310953",
+                    "transponder_type": "AIS-A",
+                    "length": "89.0",
+                    "width": "14.0"
+                },{
+                    "count": 40,
+                    "shipname": "FRIESLAND ONE",
+                    "callsign": "0WDE6789",
+                    "imo": "9310953",
+                    "transponder_type": "AIS-A",
+                    "length": "89.0",
+                    "width": "14.0"
+                },{
+                    "count": 30,
+                    "shipname": "OTHERSHIP",
+                    "callsign": "WDE5000",
+                    "imo": "9310965",
+                    "transponder_type": "AIS-A",
+                    "length": "90.0",
+                    "width": "15.0"
+                }]
+            )
 
         result = summarize_identifiers(segment)
 
-        assert result == {
-            "callsign": [ {
-                "count": 45,
-                "value": "WDE6789"
-            }],
-            "first_pos_timestamp": None,
-            "first_timestamp": None,
-            "ident_count": 45,
-            "imo": [ {
-                "count": 45,
-                "value": "9310953"
-            }],
-            "last_pos_timestamp": None,
-            "last_timestamp": None,
-            "length": [ {
-                "count": 45,
-                "value": "89.0"
-            }],
-            "msg_count": 340,
-            "n_callsign": [ {
-                "count": 45,
-                "value": "WDE6789"
-            }],
-            "n_imo": [ {
-                "count": 45,
-                "value": "9310953"
-            }],
-            "n_shipname": [ {
-                "count": 45,
-                "value": "FRIESLAND"
-            }],
-            "noise": False,
-            "pos_count": 295,
-            "seg_id": "338013000-2017-07-16T19:15:55.000000Z-1",
-            "shipname": [ {
-                "count": 45,
-                "value": "FRIESLAND"
-            }],
-            "shiptype": None,
-            "ssvid": "338013000",
-            "timestamp": 1500508800.0,
-            "width": [ {
-                "count": 45,
-                "value": "14.0"
-            }]
-        }
+        assert result == expected_segment_identities(
+            segment,
+            msg_count=410,
+            pos_count=295,
+            ident_count=115,
+            shipname=[
+                counted_value("FRIESLAND ONE", 85),
+                counted_value("OTHERSHIP", 30),
+            ],
+            callsign=[
+                counted_value("0WDE6789", 85),
+                counted_value("WDE5000", 30),
+            ],
+            imo=[
+                counted_value("9310953", 85),
+                counted_value("9310965", 30),
+            ],
+            n_shipname=[
+                counted_value("FRIESLAND1", 85),
+                counted_value("OTHERSHIP", 30),
+            ],
+            n_callsign=[
+                counted_value("WDE6789", 85),
+                counted_value("WDE5000", 30),
+            ],
+            n_imo=[
+                counted_value("9310953", 85),
+                counted_value("9310965", 30),
+            ],
+            length=[
+                counted_value("89.0", 85),
+                counted_value("90.0", 30),
+            ],
+            width=[
+                counted_value("14.0", 85),
+                counted_value("15.0", 30),
 
+            ],
+        )
 
-    def test_summarize_identifiers_empty_identifiers(self):
-        segment = {
-            "seg_id": "338013000-2017-07-16T19:15:55.000000Z-1",
-            "frag_id": "338013000-2017-07-20T00:27:29.000000Z-1",
-            "ssvid": "338013000",
-            "timestamp": as_timestamp("2017-07-20 00:00:00.000000 UTC"),
-            "daily_msg_count": 295,
-            "daily_identities": [{
-                "count": 45,
-                "shipname": "",
-                "callsign": "",
-                "imo": "",
-                "transponder_type": "AIS-A",
-                "length": "89.0",
-                "width": "14.0"
-            }],
-            "daily_destinations": [{
-                "count": 45,
-                "destination": "FISHING GROUND"
-            }],
-            "first_timestamp": as_timestamp("2017-07-16 19:15:55.000000 UTC"),
-            "cumulative_msg_count": "931",
-            "cumulative_identities": [{
-                "count": 243,
-                "shipname": "",
-                "callsign": "",
-                "imo": "",
-                "transponder_type": "AIS-A",
-                "length": "89.0",
-                "width": "14.0"
-            }, {
-                "count": 2,
-                "shipname": "",
-                "callsign": "",
-                "imo": "",
-                "transponder_type": "AIS-A",
-                "length": "505.0",
-                "width": "14.0"
-            }],
-            "cumulative_destinations": [{
-                "count": 38,
-                "destination": "SUVA FIJI"
-            }, {
-                "count": 205,
-                "destination": "FISHING GROUND"
-            }, {
-                "count": 2,
-                "destination": "BIRHIL`\"\u0026BOUND"
-            }]
-        }
+    def test_summarize_identifiers_discarding_noise(self):
+        segment = build_example_segment_with_identities(
+            daily_msg_count=295,
+            daily_identities=[
+                {
+                    "count": 45,
+                    "shipname": "FRIESLAND ONE",
+                    "callsign": "0WDE6789",
+                    "imo": "9310953",
+                    "transponder_type": "AIS-A",
+                    "length": "89.0",
+                    "width": "14.0"
+                },{
+                    "count": 30,
+                    "shipname": "000",
+                    "callsign": "000",
+                    "imo": "9310964",
+                    "transponder_type": "AIS-A",
+                    "length": None,
+                    "width": None
+                }]
+            )
 
         result = summarize_identifiers(segment)
 
-        assert result == {
-            "callsign": [ {
-                "count": 45,
-                "value": ""
-            } ],
-            "first_pos_timestamp": None,
-            "first_timestamp": None,
-            "ident_count": 45,
-            "imo": [ {
-                "count": 45,
-                "value": ""
-            } ],
-            "last_pos_timestamp": None,
-            "last_timestamp": None,
-            "length": [ {
-                "count": 45,
-                "value": "89.0"
-            } ],
-            "msg_count": 340,
-            "n_callsign": None,
-            "n_imo": None,
-            "n_shipname": None,
-            "noise": False,
-            "pos_count": 295,
-            "seg_id": "338013000-2017-07-16T19:15:55.000000Z-1",
-            "shipname": [ {
-                "count": 45,
-                "value": ""
-            } ],
-            "shiptype": None,
-            "ssvid": "338013000",
-            "timestamp": 1500508800.0,
-            "width": [ {
-                "count": 45,
-                "value": "14.0"
-            } ]
-        }
-
+        assert result == expected_segment_identities(
+            segment,
+            msg_count=370,
+            pos_count=295,
+            ident_count=75,
+            shipname=[ counted_value("FRIESLAND ONE", 45), ],
+            callsign=[ counted_value("0WDE6789", 45), ],
+            imo=[ counted_value("9310953", 45), ],
+            n_shipname=[ counted_value("FRIESLAND1", 45), ],
+            n_callsign=[ counted_value("WDE6789", 45), ],
+            n_imo=[ counted_value("9310953", 45), ],
+            length=[ counted_value("89.0", 45), ],
+            width=[ counted_value("14.0", 45), ],
+        )


### PR DESCRIPTION
See https://globalfishingwatch.atlassian.net/browse/PIPELINE-1262.

This PR changes the way normalized and denormalized values are accumulated on segment identity daily by filtering both values using the same logic before accumulating counts. This makes it so that noisy values that are discarded by the normalization function are also discarded on denormalized values, which makes frequencies match more closely. This causes the "most frequent value" logic that's used on `vessel_info` and similar to work better so that it's more common that the denormalized value on that table is the denormalized version for the normalized value.

We also updated the normalization library `shipdataprocess` to the latest released version.

The final change included in this PR is the removal of both `noise` and `shiptype`, which were deprecated on pipe 2.5. This might break steps further down in the pipeline but we'll fix them as they happen.