### PR TITLE
Removes the use of noise and shiptype.

### DIFF
--- a/assets/segment_info.schema.json
+++ b/assets/segment_info.schema.json
@@ -49,12 +49,6 @@
     "description": "Number of identity messages in the segment. Note that some messages can contain both position and identity"
   },
   {
-    "mode": "NULLABLE",
-    "name": "noise",
-    "type": "BOOLEAN",
-    "description": "If true, then this is a noise segment, usually because of an invalid lat or lon value.  Messages in these segments should be filtered out"
-  },
-  {
     "fields": [
       {
         "mode": "NULLABLE",
@@ -209,32 +203,6 @@
     "name": "n_imo",
     "type": "RECORD",
     "description": "Most commonly occuring valid imo number for this segment"
-  },
-  {
-    "fields": [
-      {
-        "mode": "NULLABLE",
-        "name": "value",
-        "type": "STRING",
-        "description": "field value"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "count",
-        "type": "INTEGER",
-        "description": "Number of times the this field value occured for this segment "
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "freq",
-        "type": "FLOAT",
-        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
-      }
-    ],
-    "mode": "NULLABLE",
-    "name": "shiptype",
-    "type": "RECORD",
-    "description": "Most commonly occuring shiptype for this segment.  Note that shiptype is already normalized in the source messages."
   },
   {
     "fields": [

--- a/assets/segment_info.sql.j2
+++ b/assets/segment_info.sql.j2
@@ -40,14 +40,12 @@ WITH
     SUM(msg_count) as msg_count,
     SUM(pos_count) as pos_count,
     SUM(ident_count) as ident_count,
-    LOGICAL_OR(noise) as noise,
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(shipname  )), SUM(ident_count), mostCommonMinFreq()) as shipname,
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(callsign  )), SUM(ident_count), mostCommonMinFreq()) as callsign,
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(imo       )), SUM(ident_count), mostCommonMinFreq()) as imo,
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_shipname)), SUM(ident_count), mostCommonMinFreq()) as n_shipname,
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_callsign)), SUM(ident_count), mostCommonMinFreq()) as n_callsign,
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_imo     )), SUM(ident_count), mostCommonMinFreq()) as n_imo,
-    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(shiptype  )), SUM(ident_count), mostCommonMinFreq()) as shiptype,
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(length    )), SUM(ident_count), mostCommonMinFreq()) as length,
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(width     )), SUM(ident_count), mostCommonMinFreq()) as width
   FROM

--- a/assets/segment_vessel_daily.schema.json
+++ b/assets/segment_vessel_daily.schema.json
@@ -66,12 +66,6 @@
     "description": "Number of positional messages in the segment over WINDOW_DAYS"
   },
   {
-    "mode": "NULLABLE",
-    "name": "noise",
-    "type": "BOOLEAN",
-    "description": "If true, then this is a noise segment, usually because of an invalid lat or lon value.  Messages in these segments should be filtered out"
-  },
-  {
     "fields": [
       {
         "mode": "NULLABLE",
@@ -226,32 +220,6 @@
     "name": "n_imo",
     "type": "RECORD",
     "description": "Most commonly occuring valid imo number for this segment over WINDOW_DAYS"
-  },
-  {
-    "fields": [
-      {
-        "mode": "NULLABLE",
-        "name": "value",
-        "type": "STRING",
-        "description": "field value"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "count",
-        "type": "INTEGER",
-        "description": "Number of times the this field value occured for this segment for this day"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "freq",
-        "type": "FLOAT",
-        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
-      }
-    ],
-    "mode": "NULLABLE",
-    "name": "shiptype",
-    "type": "RECORD",
-    "description": "Most commonly occuring shiptype for this segment over WINDOW_DAYS.  Note that shiptype is already normalized in the source messages."
   },
   {
     "fields": [

--- a/assets/segment_vessel_daily.sql.j2
+++ b/assets/segment_vessel_daily.sql.j2
@@ -49,14 +49,12 @@ WITH
     MAX(last_pos_timestamp) as last_pos_timestamp,
     SUM(msg_count) as msg_count,
     SUM(pos_count) as pos_count,
-    LOGICAL_OR(noise) as noise,
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(shipname  )), SUM(ident_count), mostCommonMinFreq()) as shipname,
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(callsign  )), SUM(ident_count), mostCommonMinFreq()) as callsign,
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(imo       )), SUM(ident_count), mostCommonMinFreq()) as imo,
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_shipname)), SUM(ident_count), mostCommonMinFreq()) as n_shipname,
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_callsign)), SUM(ident_count), mostCommonMinFreq()) as n_callsign,
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_imo     )), SUM(ident_count), mostCommonMinFreq()) as n_imo,
-    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(shiptype  )), SUM(ident_count), mostCommonMinFreq()) as shiptype,
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(length    )), SUM(ident_count), mostCommonMinFreq()) as length,
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(width     )), SUM(ident_count), mostCommonMinFreq()) as width
   FROM
@@ -74,8 +72,7 @@ WITH
     ssvid,
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_shipname)), SUM(ident_count), mostCommonMinFreq()) as n_shipname,
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_callsign)), SUM(ident_count), mostCommonMinFreq()) as n_callsign,
-    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_imo     )), SUM(ident_count), mostCommonMinFreq()) as n_imo,
-    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(shiptype  )), SUM(ident_count), mostCommonMinFreq()) as shiptype
+    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_imo     )), SUM(ident_count), mostCommonMinFreq()) as n_imo
   FROM
     segments
   GROUP BY
@@ -94,7 +91,7 @@ WITH
   FROM
     segments
   WHERE
-    NOT noise AND pos_count > spoofingThreshold()
+    pos_count > spoofingThreshold()
   ),
   #
   # Order all the good segments within a single SSVID and capture the start timestamp of the following segment
@@ -135,8 +132,7 @@ WITH
     LEAST(
       IFNULL(n_shipname.freq, 1.0),
       IFNULL(n_callsign.freq, 1.0),
-      IFNULL(n_imo.freq, 1.0),
-      IFNULL(shiptype.freq, 1.0)
+      IFNULL(n_imo.freq, 1.0)
      ) > singleIdentMinFreq()
   ),
   #

--- a/assets/vessel_info.schema.json
+++ b/assets/vessel_info.schema.json
@@ -213,32 +213,6 @@
       }
     ],
     "mode": "NULLABLE",
-    "name": "shiptype",
-    "type": "RECORD",
-    "description": "Most commonly occuring shiptype for this vessel.  Note that shiptype is already normalized in the source messages."
-  },
-  {
-    "fields": [
-      {
-        "mode": "NULLABLE",
-        "name": "value",
-        "type": "STRING",
-        "description": "field value"
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "count",
-        "type": "INTEGER",
-        "description": "Number of times the this field value occured for this vessel "
-      },
-      {
-        "mode": "NULLABLE",
-        "name": "freq",
-        "type": "FLOAT",
-        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
-      }
-    ],
-    "mode": "NULLABLE",
     "name": "length",
     "type": "RECORD",
     "description": "Most commonly occuring length for this vessel."

--- a/assets/vessel_info.sql.j2
+++ b/assets/vessel_info.sql.j2
@@ -108,7 +108,6 @@ WITH
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_shipname)), SUM(ident_count), mostCommonMinFreq()) as n_shipname,
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_callsign)), SUM(ident_count), mostCommonMinFreq()) as n_callsign,
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(n_imo     )), SUM(ident_count), mostCommonMinFreq()) as n_imo,
-    minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(shiptype  )), SUM(ident_count), mostCommonMinFreq()) as shiptype,
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(length    )), SUM(ident_count), mostCommonMinFreq()) as length,
     minFreqFilter(mostCommon(ARRAY_CONCAT_AGG(width     )), SUM(ident_count), mostCommonMinFreq()) as width
   FROM


### PR DESCRIPTION
* The `segment_identity_daily` no longer generate those fields and that impacts on following tables, fixing the absence of those fields in following tables.

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-1262