### PR TITLE
Whitelist the messages segmented strcit to the schema before writting

### DIFF
--- a/pipe_segment/pipeline.py
+++ b/pipe_segment/pipeline.py
@@ -22,6 +22,7 @@ from pipe_segment.transform.tag_with_fragid_and_timebin import \
     TagWithFragIdAndTimeBin
 from pipe_segment.transform.tag_with_seg_id import TagWithSegId
 from pipe_segment.transform.write_date_sharded import WriteDateSharded
+from pipe_segment.transform.whitelist_messages_segmented import WhitelistFields
 
 from .tools import as_timestamp, datetimeFromTimestamp
 
@@ -179,6 +180,7 @@ class SegmentPipeline:
             {"segmap": msg_segmap, "target": tagged_messages}
             | "GroupMsgsWithMap" >> beam.CoGroupByKey()
             | "TagMsgsWithSegId" >> TagWithSegId()
+            | "WhitelistFields" >> WhitelistFields()
             | "WriteMessages"
             >> WriteDateSharded(
                 self.options.msg_dest,

--- a/pipe_segment/transform/whitelist_messages_segmented.py
+++ b/pipe_segment/transform/whitelist_messages_segmented.py
@@ -1,0 +1,12 @@
+import apache_beam as beam
+from pipe_segment.message_schema import message_output_schema as mos
+
+fieldnames = list(map(lambda x: x['name'], mos['fields']))
+
+class WhitelistFields(beam.PTransform):
+
+    def whitelist(self, elem):
+        return {field:elem[field] for field in fieldnames}
+
+    def expand(self, xs):
+        return xs | beam.Map(self.whitelist)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="pipe_segment",
-    version='4.1.1',
+    version='4.1.2',
     packages=find_packages(exclude=["test*.*", "tests"]),
     include_package_data=True
 )


### PR DESCRIPTION
- The segment process uses the fields of the normalized tables to write the messages_segmented_, the 2023 normalized tables comes from `pipe_ais_sources_v20220628.pipe_nmea_normalized_` and has a new field compared to the previous ones (spire and orbcomm) this changes does a whitelist of the required fields needed by the core pipeline.
- Increments the version from `v4.1.1` to `v4.1.2`

Related to> https://globalfishingwatch.atlassian.net/browse/PIPELINE-1316