### PR TITLE
Pipe-v2.5: Adds support for python-3.8 and AB-2.49

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,14 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [UNRELEASED]
 
+## v3.3.0 - 2023-07-26
+
+### Added
+
+* [PIPELINE-1319](https://globalfishingwatch.atlassian.net/browse/PIPELINE-1319): Adds
+  support for runnig the code with `python-3.8` and updated the google sdk from
+  `2.40.0` to [2.49.0](https://github.com/apache/beam/releases/tag/v2.49.0).
+
 ## v3.2.3 - 2022-08-02
 
 ### Changed

--- a/Dockerfile-scheduler
+++ b/Dockerfile-scheduler
@@ -1,4 +1,4 @@
-FROM gcr.io/world-fishing-827/github.com/globalfishingwatch/gfw-bash-pipeline:latest-python3.7
+FROM gcr.io/world-fishing-827/github.com/globalfishingwatch/gfw-bash-pipeline:latest-python3.8
 
 # Setup scheduler-specific dependencies
 COPY ./requirements-scheduler.txt ./

--- a/Dockerfile-worker
+++ b/Dockerfile-worker
@@ -1,6 +1,9 @@
-FROM apache/beam_python3.7_sdk:2.40.0
+FROM apache/beam_python3.8_sdk:2.49.0
 
 # Setup local application dependencies
 COPY ./requirements-worker.txt ./
 RUN pip install -r requirements-worker.txt
+
+# Set the entrypoint to the Apache Beam SDK launcher.
+ENTRYPOINT ["/opt/apache/beam/boot"]
 

--- a/pipe_segment/__init__.py
+++ b/pipe_segment/__init__.py
@@ -3,12 +3,12 @@ Tools for parsing and normalizing AIS from Orbcomm using dataflow
 """
 
 
-__version__ = '3.2.3'
+__version__ = '3.3.0'
 __author__ = 'Paul Woods'
 __email__ = 'paul@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/pipe-segment'
 __license__ = """
-Copyright 2019 Global Fishing Watch Inc.
+Copyright 2023 Global Fishing Watch Inc.
 Authors:
 
 Paul Woods <paul@globalfishingwatch.org>

--- a/requirements-scheduler.txt
+++ b/requirements-scheduler.txt
@@ -1,3 +1,3 @@
-apache-beam[gcp]==2.40.0
-pytest==6.2.5
+apache-beam[gcp]==2.49.0
+pytest==7.2.2
 jinja2-cli==0.8.2


### PR DESCRIPTION
This is for pipe-v2.5:
- Increments the support from `python-3.7` to `python-3.8`, it was required because the last version of AB only supports py3.8.
- Increments the Apache Beam version from [2.40](https://github.com/apache/beam/releases/tag/v2.40.0) to [2.49](https://github.com/apache/beam/releases/tag/v2.49.0)

Tests are running ok. There was an increment of warnings.

Also run the segment steps, the results were set in the `scratch_matias_ttl_60_days`.

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-1319