### PR TITLE
Adds missing configuration to satellite_timing_offsets table

### DIFF
--- a/pipe_segment/utils/ver.py
+++ b/pipe_segment/utils/ver.py
@@ -1,0 +1,6 @@
+import re
+
+def get_pipe_ver():
+    """Returns the version of the package."""
+    with open('setup.py') as rf:
+        return re.search(r"version='([0-9.]*)'", rf.read()).group(1)


### PR DESCRIPTION
- Adds column descriptions, table description and table labels to satellite_timing_offsets, that is under published dataset

Running example of `2023-01-01` writing to `scratch_matias_ttl_60_days.pipe3_satellite_timing_offsets`.:
![Screenshot from 2023-08-09 06-40-28](https://github.com/GlobalFishingWatch/pipe-segment/assets/432563/6aef9cbd-d041-4174-b27f-59224af370c0)
![Screenshot from 2023-08-09 06-40-22](https://github.com/GlobalFishingWatch/pipe-segment/assets/432563/d613033d-d5e7-49a5-a3d4-f592b0d25143)


Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-1429

NOTE: Please merge first this PR before #153 