### PR TITLE
Adds missing configuration to vessel_info table

### DIFF
--- a/assets/vessel_info.schema.json
+++ b/assets/vessel_info.schema.json
@@ -3,37 +3,37 @@
     "mode": "NULLABLE",
     "name": "vessel_id",
     "type": "STRING",
-    "description": "unique vessel id.  This table has one row per vessel_id"
+    "description": "The unique vessel id. This table has one row per vessel_id."
   },
   {
     "mode": "NULLABLE",
     "name": "ssvid",
     "type": "STRING",
-    "description": "source specific vessel id.  This is the transponder id, and for AIS this is the MMSI"
+    "description": "The source specific vessel id. This is the transponder id, and for AIS this is the MMSI."
   },
   {
     "mode": "NULLABLE",
     "name": "first_timestamp",
     "type": "TIMESTAMP",
-    "description": "Timestamp of the first message in the segment"
+    "description": "Timestamp of the first message in the segment."
   },
   {
     "mode": "NULLABLE",
     "name": "last_timestamp",
     "type": "TIMESTAMP",
-    "description": "Timestamp of the last message in the segment"
+    "description": "Timestamp of the last message in the segment."
   },
   {
     "mode": "NULLABLE",
     "name": "msg_count",
     "type": "INTEGER",
-    "description": "Total number of messages in the segment, including identiy messages and positional messages"
+    "description": "Total number of messages in the segment, including identiy messages and positional messages."
   },
   {
     "mode": "NULLABLE",
     "name": "pos_count",
     "type": "INTEGER",
-    "description": "Total number or positional messages in the segment.   Consider filtering out messages in segments with only a small number of positional messagess"
+    "description": "Total number or positional messages in the segment. Consider filtering out messages in segments with only a small number of positional messagess."
   },
   {
     "fields": [
@@ -41,25 +41,25 @@
         "mode": "NULLABLE",
         "name": "value",
         "type": "STRING",
-        "description": "field value"
+        "description": "The field value."
       },
       {
         "mode": "NULLABLE",
         "name": "count",
         "type": "INTEGER",
-        "description": "Number of times the this field value occured for this vessel"
+        "description": "Number of times the this field value occured for this vessel."
       },
       {
         "mode": "NULLABLE",
         "name": "freq",
         "type": "FLOAT",
-        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value."
       }
     ],
     "mode": "NULLABLE",
     "name": "shipname",
     "type": "RECORD",
-    "description": "Most commonly occuring shipname (unnormalized) for this vessel"
+    "description": "Most commonly occuring shipname (unnormalized) for this vessel."
   },
   {
     "fields": [
@@ -67,25 +67,25 @@
         "mode": "NULLABLE",
         "name": "value",
         "type": "STRING",
-        "description": "field value"
+        "description": "field value."
       },
       {
         "mode": "NULLABLE",
         "name": "count",
         "type": "INTEGER",
-        "description": "Number of times the this field value occured for this vessel"
+        "description": "Number of times the this field value occured for this vessel."
       },
       {
         "mode": "NULLABLE",
         "name": "freq",
         "type": "FLOAT",
-        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value."
       }
     ],
     "mode": "NULLABLE",
     "name": "callsign",
     "type": "RECORD",
-    "description": "Most commonly occuring callsign (unnormalized) for this vessel"
+    "description": "Most commonly occuring callsign (unnormalized) for this vessel."
   },
   {
     "fields": [
@@ -93,25 +93,25 @@
         "mode": "NULLABLE",
         "name": "value",
         "type": "STRING",
-        "description": "field value"
+        "description": "field value."
       },
       {
         "mode": "NULLABLE",
         "name": "count",
         "type": "INTEGER",
-        "description": "Number of times the this field value occured for this vessel"
+        "description": "Number of times the this field value occured for this vessel."
       },
       {
         "mode": "NULLABLE",
         "name": "freq",
         "type": "FLOAT",
-        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value."
       }
     ],
     "mode": "NULLABLE",
     "name": "imo",
     "type": "RECORD",
-    "description": "Most commonly occuring imo number (unvalidated) for this vessel"
+    "description": "Most commonly occuring imo number (unvalidated) for this vessel."
   },
   {
     "fields": [
@@ -119,25 +119,25 @@
         "mode": "NULLABLE",
         "name": "value",
         "type": "STRING",
-        "description": "field value"
+        "description": "field value."
       },
       {
         "mode": "NULLABLE",
         "name": "count",
         "type": "INTEGER",
-        "description": "Number of times the this field value occured for this vessel"
+        "description": "Number of times the this field value occured for this vessel."
       },
       {
         "mode": "NULLABLE",
         "name": "freq",
         "type": "FLOAT",
-        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value."
       }
     ],
     "mode": "NULLABLE",
     "name": "n_shipname",
     "type": "RECORD",
-    "description": "Most commonly occuring normalized shipname for this vessel"
+    "description": "Most commonly occuring normalized shipname for this vessel."
   },
   {
     "fields": [
@@ -145,25 +145,25 @@
         "mode": "NULLABLE",
         "name": "value",
         "type": "STRING",
-        "description": "field value"
+        "description": "field value."
       },
       {
         "mode": "NULLABLE",
         "name": "count",
         "type": "INTEGER",
-        "description": "Number of times the this field value occured for this vessel"
+        "description": "Number of times the this field value occured for this vessel."
       },
       {
         "mode": "NULLABLE",
         "name": "freq",
         "type": "FLOAT",
-        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value."
       }
     ],
     "mode": "NULLABLE",
     "name": "n_callsign",
     "type": "RECORD",
-    "description": "Most commonly occuring normalized callsign for this vessel"
+    "description": "Most commonly occuring normalized callsign for this vessel."
   },
   {
     "fields": [
@@ -171,25 +171,25 @@
         "mode": "NULLABLE",
         "name": "value",
         "type": "STRING",
-        "description": "field value"
+        "description": "field value."
       },
       {
         "mode": "NULLABLE",
         "name": "count",
         "type": "INTEGER",
-        "description": "Number of times the this field value occured for this vessel"
+        "description": "Number of times the this field value occured for this vessel."
       },
       {
         "mode": "NULLABLE",
         "name": "freq",
         "type": "FLOAT",
-        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value."
       }
     ],
     "mode": "NULLABLE",
     "name": "n_imo",
     "type": "RECORD",
-    "description": "Most commonly occuring valid imo number for this vessel"
+    "description": "Most commonly occuring valid imo number for this vessel."
   },
   {
     "fields": [
@@ -197,19 +197,19 @@
         "mode": "NULLABLE",
         "name": "value",
         "type": "STRING",
-        "description": "field value"
+        "description": "field value."
       },
       {
         "mode": "NULLABLE",
         "name": "count",
         "type": "INTEGER",
-        "description": "Number of times the this field value occured for this vessel "
+        "description": "Number of times the this field value occured for this vessel."
       },
       {
         "mode": "NULLABLE",
         "name": "freq",
         "type": "FLOAT",
-        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value."
       }
     ],
     "mode": "NULLABLE",
@@ -223,19 +223,19 @@
         "mode": "NULLABLE",
         "name": "value",
         "type": "STRING",
-        "description": "field value"
+        "description": "field value."
       },
       {
         "mode": "NULLABLE",
         "name": "count",
         "type": "INTEGER",
-        "description": "Number of times the this field value occured for this vessel "
+        "description": "Number of times the this field value occured for this vessel."
       },
       {
         "mode": "NULLABLE",
         "name": "freq",
         "type": "FLOAT",
-        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value"
+        "description": "The relative frequency of this value to all values present in this field.  Range from 0.0 to 1.0.   A value of 1.0 indicates that this was the only value."
       }
     ],
     "mode": "NULLABLE",
@@ -243,6 +243,5 @@
     "type": "RECORD",
     "description": "Most commonly occuring width for this vessel."
   }
-
 ]
 

--- a/pipe_segment/utils/ver.py
+++ b/pipe_segment/utils/ver.py
@@ -1,0 +1,6 @@
+import re
+
+def get_pipe_ver():
+    """Returns the version of the package."""
+    with open('setup.py') as rf:
+        return re.search(r"version='([0-9.]*)'", rf.read()).group(1)

--- a/scripts/vessel_info.sh
+++ b/scripts/vessel_info.sh
@@ -42,14 +42,17 @@ done
 echo "Ensuring table ${DEST_TABLE} exists"
 TABLE_DESC=(
   "* Pipeline: ${PIPELINE} ${PIPELINE_VERSION}"
-  "* Source: ${SOURCE_TABLE}"
+  "* Creates a table with one row per vessel_id from segment_identity_daily using seg_id to vesse_id mappings from segment_identity_window including the entire time range from the source tables"
+  "* Source Identity: ${SEGMENT_IDENTITY_TABLE}"
+  "* Source Vessel: ${SEGMENT_VESSEL_TABLE}"
+  "* Most common minimal frequence: ${MOST_COMMON_MIN_FREQ}"
   "* Command:"
   "$(basename $0)"
   "$@"
 )
 TABLE_DESC=$( IFS=$'\n'; echo "${TABLE_DESC[*]}" )
 SCHEMA=${ASSETS}/${PROCESS}.schema.json
-bq mk --force \
+bq mk --force -t \
   --description "${TABLE_DESC}" \
   ${DEST_TABLE} \
   ${SCHEMA}
@@ -72,7 +75,8 @@ jinja2 ${SQL} \
    -D segment_vessel_daily=${SEGMENT_VESSEL_TABLE//:/.} \
    -D most_common_min_freq=${MOST_COMMON_MIN_FREQ} \
    | bq query --headless --max_rows=0 --allow_large_results --replace \
-     ${LABELS_PARAM} --destination_table ${DEST_TABLE}
+     ${LABELS_PARAM} --destination_table ${DEST_TABLE} \
+     --destination_schema ${SCHEMA}
 
 if [ "$?" -ne 0 ]; then
   echo "  Unable to insert records for table ${DEST_TABLE}"
@@ -80,5 +84,10 @@ if [ "$?" -ne 0 ]; then
 fi
 
 bq update --description "${TABLE_DESC}" ${DEST_TABLE}
+for label in ${LABELS//,/ }; do
+  echo "Setting label <$label> to table <$DEST_TABLE>"
+  bq update --set_label ${label} ${DEST_TABLE}
+done
+
 
 echo "DONE ${DEST_TABLE}."


### PR DESCRIPTION
- Adds column descriptions in querying script, the descriptions were already written but were not applied to the `vessel_info`.
- Adds table description and table labels to the `vessel_info`, that is under published dataset

Running example of 2023-01-01 writing to `scratch_matias_ttl_60_days.pipe3_vessel_info`:
![Screenshot from 2023-08-09 08-02-11](https://github.com/GlobalFishingWatch/pipe-segment/assets/432563/076b6dcc-fd18-4195-9606-2aa4e3ab039e)
![Screenshot from 2023-08-09 08-01-54](https://github.com/GlobalFishingWatch/pipe-segment/assets/432563/66c7ed32-e564-4654-aafd-9f177c7afe38)

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-1430

NOTE: Please merge first this PR before #153