### PR TITLE
Makes the segment step runs for the VMS data. Disabled satellite dependencies and fields not present.

### DIFF
--- a/pipe_segment/__main__.py
+++ b/pipe_segment/__main__.py
@@ -19,7 +19,8 @@ def run(args):
 
     seg_options = options.view_as(SegmentOptions)
     gcloud_options = options.view_as(GoogleCloudOptions)
-    remove_satellite_offsets_content(seg_options.sat_offset_dest, seg_options.date_range, gcloud_options.labels, gcloud_options.project)
+    if seg_options.sat_offset_dest:
+        remove_satellite_offsets_content(seg_options.sat_offset_dest, seg_options.date_range, gcloud_options.labels, gcloud_options.project)
 
     return pipeline.run(options)
 

--- a/pipe_segment/transform/fragment.py
+++ b/pipe_segment/transform/fragment.py
@@ -12,9 +12,6 @@ logger = logging.getLogger(__file__)
 logger.setLevel(logging.DEBUG)
 
 
-def key_or_none(d, k):
-    return d[k] if k in d else None
-
 def none_to_inf(x):
     return math.inf if (x is None) else x
 
@@ -124,19 +121,19 @@ class Fragment(PTransform):
                 none_to_inf(x["lat"]),
                 none_to_inf(x["speed"]),
                 none_to_inf(x["course"]),
-                none_to_inf(key_or_none(x,"heading")),
-                none_to_blank(key_or_none(x,"destination")),
-                none_to_inf(key_or_none(x,"length")),
-                none_to_inf(key_or_none(x,"width")),
+                none_to_inf(x.get("heading")),
+                none_to_blank(x.get("destination")),
+                none_to_inf(x.get("length")),
+                none_to_inf(x.get("width")),
                 none_to_blank(x["shiptype"]),
-                none_to_inf(key_or_none(x,"status")),
+                none_to_inf(x.get("status")),
                 none_to_inf(x["source"]),
                 none_to_inf(x["type"]),
                 none_to_blank(x["shipname"]),
                 none_to_blank(x["callsign"]),
-                none_to_blank(key_or_none(x,"imo")),
-                none_to_blank(key_or_none(x,"receiver_type")),
-                none_to_blank(key_or_none(x,"receiver")),
+                none_to_blank(x.get("imo")),
+                none_to_blank(x.get("receiver_type")),
+                none_to_blank(x.get("receiver")),
             )
         )
         for key, value in self._fragmenter.fragment(messages):

--- a/pipe_segment/transform/fragment.py
+++ b/pipe_segment/transform/fragment.py
@@ -12,6 +12,9 @@ logger = logging.getLogger(__file__)
 logger.setLevel(logging.DEBUG)
 
 
+def key_or_none(d, k):
+    return d[k] if k in d else None
+
 def none_to_inf(x):
     return math.inf if (x is None) else x
 
@@ -121,19 +124,19 @@ class Fragment(PTransform):
                 none_to_inf(x["lat"]),
                 none_to_inf(x["speed"]),
                 none_to_inf(x["course"]),
-                none_to_inf(x["heading"]),
-                none_to_blank(x["destination"]),
-                none_to_inf(x["length"]),
-                none_to_inf(x["width"]),
+                none_to_inf(key_or_none(x,"heading")),
+                none_to_blank(key_or_none(x,"destination")),
+                none_to_inf(key_or_none(x,"length")),
+                none_to_inf(key_or_none(x,"width")),
                 none_to_blank(x["shiptype"]),
-                none_to_inf(x["status"]),
+                none_to_inf(key_or_none(x,"status")),
                 none_to_inf(x["source"]),
                 none_to_inf(x["type"]),
                 none_to_blank(x["shipname"]),
                 none_to_blank(x["callsign"]),
-                none_to_blank(x["imo"]),
-                none_to_blank(x["receiver_type"]),
-                none_to_blank(x["receiver"]),
+                none_to_blank(key_or_none(x,"imo")),
+                none_to_blank(key_or_none(x,"receiver_type")),
+                none_to_blank(key_or_none(x,"receiver")),
             )
         )
         for key, value in self._fragmenter.fragment(messages):

--- a/pipe_segment/transform/whitelist_messages_segmented.py
+++ b/pipe_segment/transform/whitelist_messages_segmented.py
@@ -6,7 +6,7 @@ fieldnames = list(map(lambda x: x['name'], mos['fields']))
 class WhitelistFields(beam.PTransform):
 
     def whitelist(self, elem):
-        return {field:elem[field] for field in fieldnames}
+        return {field:elem[field] for field in fieldnames if field in elem}
 
     def expand(self, xs):
         return xs | beam.Map(self.whitelist)


### PR DESCRIPTION
Makes the segment step runs for the `VMS` data. Disabled satellite dependencies and fields not present.
- The `VMS` data does not have satellite information, so the enabling the remove of the satellite offset content only if the `sat_offset_dest` is set.
- Let pass fields that are not coming with the `VMS` data when building the fragments. Those fields are:
  - `heading`
  - `destination`
  - `length`
  - `width`
  - `status`
  - `imo`
  - `receiver_type`
  - `receiver`
- Does the whitelist of messages segmented with the fields available.

Related with> https://globalfishingwatch.atlassian.net/browse/VMS-123