### PR TITLE
Gruping by ssvid, then frag, then date, then bins.

### DIFF
--- a/pipe_segment/pipeline.py
+++ b/pipe_segment/pipeline.py
@@ -51,7 +51,7 @@ def time_bin_ndx(dtime, time_bins):
 
 def time_bin_key(x, time_bins):
     dtime = datetimeFromTimestamp(x["timestamp"])
-    return x["frag_id"], str(dtime.date()), time_bin_ndx(dtime, time_bins)
+    return x['ssvid'], x["frag_id"], str(dtime.date()), time_bin_ndx(dtime, time_bins)
 
 
 class SegmentPipeline:


### PR DESCRIPTION
Following @bitsofbits and @andres-arana suggestions.
Grouping by `ssvid`, then `frag_id`, then `date`, then `bins`.
The `None` `frag_id` are originated with the identity messages (without `lat`/`lon`) such as the `AIS.5` / `AIS.24` / etc..
This new key keeps the `None` `frag_id` away from grouping only them together avoiding an OOM in DF.
Each `None` `frag_id` will be grouped in the same `ssvid` now.