### PR TITLE
PIPELINE-2125: Gruping by ssvid, then frag, then date, then bins. 

### DIFF
--- a/pipe_segment/pipeline.py
+++ b/pipe_segment/pipeline.py
@@ -60,7 +60,7 @@ def time_bin_ndx(dtime, time_bins):
 
 def time_bin_key(x, time_bins):
     dtime = datetimeFromTimestamp(x["timestamp"])
-    return x["frag_id"], str(dtime.date()), time_bin_ndx(dtime, time_bins)
+    return x['ssvid'], x["frag_id"], str(dtime.date()), time_bin_ndx(dtime, time_bins)
 
 
 class SegmentPipeline:


### PR DESCRIPTION
This keep `none` `frag_ids` away from grouping together avoiding OOM.
Those messages are from identity messages and now will be grouped matching the `ssvid`.

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-2125