### PR TITLE
Separates the input/output fragment args

### DIFF
--- a/pipe_segment/options/segment.py
+++ b/pipe_segment/options/segment.py
@@ -45,7 +45,7 @@ class SegmentOptions(PipelineOptions):
         required.add_argument(
             "--fragment_tbl",
             required=True,
-            help="Bigquery table to read and write fragments",
+            help="Bigquery table to read fragments",
         )
         required.add_argument(
             "--segment_dest",
@@ -116,4 +116,9 @@ class SegmentOptions(PipelineOptions):
             "--bins_per_day",
             default=4,
             help="Amount of containers per day to tag fragments and messages.",
+        )
+        optional.add_argument(
+            "--output_fragment_tbl",
+            help="Bigquery table to write fragments",
+            default=None
         )

--- a/pipe_segment/pipeline.py
+++ b/pipe_segment/pipeline.py
@@ -60,6 +60,10 @@ class SegmentPipeline:
         self.options = options.view_as(SegmentOptions)
         self.date_range = parse_date_range(self.options.date_range)
         self.satellite_offsets_writer = None
+        if self.options.output_fragment_tbl is None:
+            self.options.output_fragment_tbl = self.options.fragment_tbl
+            logging.info("The output_fragment_tbl defaults to = %s" % self.options.fragment_tbl)
+
 
     @property
     def merge_params(self):
@@ -131,7 +135,7 @@ class SegmentPipeline:
         new_fragments = fragmented[Fragment.OUTPUT_TAG_FRAGMENTS]
 
         new_fragments | WriteDateSharded(
-            self.options.fragment_tbl, self.cloud_options.project, Fragment.schema
+            self.options.output_fragment_tbl, self.cloud_options.project, Fragment.schema
         )
 
         existing_fragments = pipeline | ReadFragments(


### PR DESCRIPTION
Noted that the `msg_dest`, `segment_dest` and `sat_offset_dest` is only used for writing while the `fragment_tbl` is used as source and as destination.. Separating them is useful for avoiding to do a copy of all the tables to reproduce a behavour.
- Separates the input from the output of fragment table argument.
- Defaults the output with the input value if not set.


Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-2398