### PR TITLE
Includes the ssvid to balance the load

### DIFF
--- a/pipe_segment/pipeline.py
+++ b/pipe_segment/pipeline.py
@@ -51,7 +51,7 @@ def time_bin_ndx(dtime, time_bins):
 
 def time_bin_key(x, time_bins):
     dtime = datetimeFromTimestamp(x["timestamp"])
-    return x["frag_id"], str(dtime.date()), time_bin_ndx(dtime, time_bins)
+    return x["ssvid"], x["frag_id"], str(dtime.date()), time_bin_ndx(dtime, time_bins)
 
 
 def strip_identity_and_destination(fragment):

--- a/pipe_segment/transform/create_segment_map.py
+++ b/pipe_segment/transform/create_segment_map.py
@@ -96,7 +96,7 @@ class CreateSegmentMap(beam.PTransform):
                 for frag_day, fid in seg_fids:
                     assert isinstance(frag_day, date), (frag_day, sid, fid)
                     assert frag_day == day
-                    yield {"seg_id": sid, "date": frag_day, "frag_id": fid}
+                    yield {"ssvid": frag_map[fid]["ssvid"], "seg_id": sid, "date": frag_day, "frag_id": fid}
 
             # Create new segments where we do NOT match to a segment and
             # yield them
@@ -104,7 +104,7 @@ class CreateSegmentMap(beam.PTransform):
             for fid in daily_fids:
                 sid = fid
                 open_segs[sid] = [(day, fid)]
-                yield {"seg_id": sid, "date": day, "frag_id": fid}
+                yield {"ssvid": frag_map[fid]["ssvid"], "seg_id": sid, "date": day, "frag_id": fid}
 
             # Add any active segs to open_segs
             for k, v in active_segs.items():

--- a/pipe_segment/transform/tag_with_fragid_and_timebin.py
+++ b/pipe_segment/transform/tag_with_fragid_and_timebin.py
@@ -16,7 +16,7 @@ class TagWithFragIdAndTimeBin(PTransform):
     def tag_frags(self, x):
         if self.start_date <= x["date"] <= self.end_date:
             for sub_bin in range(self.bins_per_day):
-                yield ((x["frag_id"], str(x["date"]), sub_bin), x)
+                yield ((x["ssvid"], x["frag_id"], str(x["date"]), sub_bin), x)
 
     def expand(self, xs):
         return xs | FlatMap(self.tag_frags)


### PR DESCRIPTION
This PR is using the #191 as base, because the stripping of identities is required for reducing memory size and this ticket intent to balance the load of hotkey. As summary, the identity messages are not position messages, so the fragment representation of those has a `frag_id` `NULL`, that mean when doing the group by key are placing all the frag_id null in only one bucket, that bucket is later processed by a worker that took a lot of time to process. That generates the hotkey, that we though it's due to the identity messages.

For achieving it, we did:
- Adds ssvid to grouping key for identity messages
- Includes the `ssvid` when `merge_fragments` function to later, in the [create_seg_map Ptransform](https://github.com/GlobalFishingWatch/pipe-segment/blob/hotfix/PIPELINE-2156-hotkey_issues/pipe_segment/pipeline.py#L165), have a valid SSVID and not a NULL one. so then, when doing the [cogrouping by key](https://github.com/GlobalFishingWatch/pipe-segment/blob/hotfix/PIPELINE-2156-hotkey_issues/pipe_segment/pipeline.py#L179). So here it changes the way, first look at the `ssvid` and the rest.

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-2156