### PR TITLE
Uses pytz.UTC to each message when fragmenting

### DIFF
--- a/pipe_segment/transform/fragment.py
+++ b/pipe_segment/transform/fragment.py
@@ -1,5 +1,6 @@
 import logging
 import math
+import pytz
 
 from apache_beam import FlatMap, PTransform
 from apache_beam.pvalue import TaggedOutput
@@ -88,7 +89,8 @@ class Fragment(PTransform):
     def _convert_message_in(msg):
         msg = msg.copy()
         msg["raw_timestamp"] = msg["timestamp"]
-        msg["timestamp"] = datetime_from_timestamp(msg["raw_timestamp"])
+        # TODO remove pytz once gspdio-segment is updated.
+        msg["timestamp"] = datetime_from_timestamp(msg["raw_timestamp"], tzinfo=pytz.UTC)
         return msg
 
     @staticmethod

--- a/requirements.txt
+++ b/requirements.txt
@@ -303,7 +303,9 @@ python-dateutil==2.9.0.post0
 python-stdnum==1.20
     # via -r requirements/prod.in
 pytz==2024.1
-    # via apache-beam
+    # via
+    #   -r requirements/prod.in
+    #   apache-beam
 redis==5.0.4
     # via apache-beam
 referencing==0.35.1

--- a/requirements/prod.in
+++ b/requirements/prod.in
@@ -8,3 +8,4 @@ python-stdnum~=1.17
 rich~=13.7
 shipdataprocess~=0.7
 ujson~=5.9
+pytz~=2024.1


### PR DESCRIPTION
- Exposes the same `pytz` version that `gpsdio-segment:v3.0.0` is using.
- Fixes the bug:
```
  File "/opt/project/pipe_segment/transform/fragment.py", line 139, in fragment                                                                                                                                                                                                 
    for key, value in self._fragmenter.fragment(messages):                                                                                                                                                                                                                      
  File "/opt/project/pipe_segment/transform/fragment_implementation.py", line 97, in fragment                                                                                                                                                                                   
    for frag in Fragmenter(messages, ssvid=ssvid, **self.fragmenter_params):                                                                                                                                                                                                    
  File "/usr/local/lib/python3.8/site-packages/gpsdio_segment/segmenter.py", line 380, in process                                                                                                                                                                               
    for msg_type, msg in self._msg_processor(self.instream):                                                                                                                                                                                                                    
  File "/usr/local/lib/python3.8/site-packages/gpsdio_segment/msg_processor.py", line 251, in __call__                                                                                                                                                                          
    self._store_info(msg)                                                                                                                                                                                                                                                       
  File "/usr/local/lib/python3.8/site-packages/gpsdio_segment/msg_processor.py", line 192, in _store_info                                                                                                                                                                       
    assert ts.tzinfo.zone == "UTC"                                                                                                                                                                                                                                              
AttributeError: 'datetime.timezone' object has no attribute 'zone' [while running 'Fragment/FlatMap(fragment)/FlatMap(fragment)'] 
```
- Place a mark to TODO when gpsdio-segment is updated.
- 