### PR TITLE
PIPELINE-2664 Add validation for all fields in VMS messages and enhance tests

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -32,6 +32,7 @@ services:
       - "gcp:/root/.config/"
 
   bigquery:
+    platform: linux/x86_64
     ports:
       - 9050:9050
     image: ghcr.io/goccy/bigquery-emulator:latest

--- a/pipe_segment/transform/invalid_values.py
+++ b/pipe_segment/transform/invalid_values.py
@@ -176,10 +176,10 @@ INVALID_VALUE_RULES_BY_MESSAGE_TYPE = {
     },
     # General VMS
     "VMS": {
-        "lon": validate_fixed_position_field(2, lambda x: x < -180 or x > 180),
-        "lat": validate_fixed_position_field(2, lambda x: x < -90 or x > 90),
-        "course": validate_fixed_position_field(0, lambda x: x < 0 or x >= 360),
-        "speed": validate_fixed_position_field(0, lambda x: x < 0),
+        "lon": validate_field(lambda x: x < -180 or x > 180),
+        "lat": validate_field(lambda x: x < -90 or x > 90),
+        "course": validate_field(lambda x: x < 0 or x >= 360),
+        "speed": validate_field(lambda x: x < 0),
     },
 }
 

--- a/pipe_segment/transform/invalid_values.py
+++ b/pipe_segment/transform/invalid_values.py
@@ -7,16 +7,19 @@ def validate_field(is_invalid):
     the `is_invalid` function returns true for a given value, it is converted
     to `None` instead. If not, the original value is returned.
 
-    Arguments:
-    `is_invalid`: Function which returns true when a given value is invalid,
-    false otherwise
+    Args:
+        is_invalid (Callable): Function which returns True when a given value is invalid,
+            False otherwise.
+
+    Returns:
+        Callable: A validator function that returns None for invalid values, or the original value.
 
     Examples:
-    ```
-    validator = validate_field(lambda x: x > 5)
-    validator(1) -> 1
-    validator(6) -> None
-    ```
+        >>> validator = validate_field(lambda x: x > 5)
+        >>> validator(1)
+        1
+        >>> validator(6)
+        None
     """
     return lambda value: None if is_invalid(value) else value
 
@@ -25,16 +28,17 @@ def float_to_fixed_point(value, precision):
     """
     Converts a given floating point value to a fixed precision decimal.
 
+    Args:
+        value (float or Decimal): The value to convert.
+        precision (int): The number of decimal places to keep.
+
+    Returns:
+        Decimal: The value rounded to the specified precision.
+
     Examples:
-    ```
-    float_to_fixed_point(120.034, 1) -> Decimal(120.0)
-    ```
+        >>> float_to_fixed_point(120.034, 1)
+        Decimal('120.0')
     """
-    # We need to generate a string which contains a number with a given number
-    # of values after the decimal point, so that we can quantize the input
-    # value to that same amount of decimal places. For example, for precision 2
-    # we get `{0:.2f}`, which when applied as a format to a number `1` we get
-    # `"1.00"`
     precision_format_string = "{{0:.{}f}}".format(precision)
     precision_decimal = decimal.Decimal(precision_format_string.format(1))
     return decimal.Decimal(value).quantize(precision_decimal)
@@ -42,15 +46,22 @@ def float_to_fixed_point(value, precision):
 
 def validate_fixed_position_field(precision, is_invalid):
     """
-    This is a specialization for `validate_field`, which converts the value to
-    a fixed point decimal before calling the `is_invalid` function.
+    Specializes `validate_field` by converting the value to a fixed point decimal
+    before calling the `is_invalid` function.
+
+    Args:
+        precision (int): Number of decimal places to use for fixed point conversion.
+        is_invalid (Callable): Function that returns True if the value is invalid.
+
+    Returns:
+        Callable: A validator function for fixed point fields.
 
     Examples:
-    ```
-    validator = validate_fixed_position_field(0, lambda x: x > 5)
-    validator(5.1) -> 5.1
-    validator(6) -> None
-    ```
+        >>> validator = validate_fixed_position_field(0, lambda x: x > 5)
+        >>> validator(5.1)
+        5.1
+        >>> validator(6)
+        None
     """
     return validate_field(
         lambda value: is_invalid(float_to_fixed_point(value, precision))
@@ -63,25 +74,23 @@ def validate_all_fields_record(is_invalid):
     according to the provided `is_invalid` function. If all are invalid, those fields
     are set to `None` in the returned record; otherwise, the original values are kept.
 
-    Arguments:
-    `is_invalid`: Function that returns True when a given value is invalid, False otherwise.
+    Args:
+        is_invalid (Callable): Function that returns True when a given value is invalid.
 
     Returns:
-    A function that takes a list of fields and a record (dict), and returns a new record
-    with the specified fields set to None if all are invalid.
+        Callable: A function that takes a list of fields and a record (dict), and returns
+        a new record with the specified fields set to None if all are invalid.
 
     Examples:
-    ```
-    validator = validate_all_fields_record(lambda x: x == 0)
-    validator(["lat", "lon"], {"lat": 0, "lon": 0}) -> {"lat": None, "lon": None}
-    validator(["lat", "lon"], {"lat": 1, "lon": 0}) -> {"lat": 1, "lon": 0}
-    ```
+        >>> validator = validate_all_fields_record(lambda x: x == 0)
+        >>> validator(["lat", "lon"], {"lat": 0, "lon": 0})
+        {'lat': None, 'lon': None}
+        >>> validator(["lat", "lon"], {"lat": 1, "lon": 0})
+        {'lat': 1, 'lon': 0}
     """
     def validate_multiple_fields(fields, record):
         not_valid = all(is_invalid(record[field]) for field in fields)
-
         return {field: None if not_valid else record[field] for field in fields}
-
     return validate_multiple_fields
 
 
@@ -196,11 +205,11 @@ def apply_field_validators(element):
     Applies the field validators to the given element. The field validators
     are defined in the `INVALID_VALUE_RULES_BY_MESSAGE_TYPE` dictionary.
 
-    Arguments:
-    `element`: The element to apply the field validators to.
+    Args:
+        element (dict): The element to apply the field validators to.
 
     Returns:
-    The element with the field validators applied.
+        dict: The element with the field validators applied.
     """
     field_validators = INVALID_VALUE_RULES_BY_MESSAGE_TYPE.get(element["type"])
 
@@ -220,11 +229,11 @@ def apply_group_validators(element):
     Applies the group validators to the given element. The group validators
     are defined in the `INVALID_GROUP_RULES_BY_MESSAGE_TYPE` dictionary.
 
-    Arguments:
-    `element`: The element to apply the group validators to.
+    Args:
+        element (dict): The element to apply the group validators to.
 
     Returns:
-    The element with the group validators applied.
+        dict: The element with the group validators applied.
     """
     group_validators = INVALID_GROUP_RULES_BY_MESSAGE_TYPE.get(element["type"])
 
@@ -255,11 +264,11 @@ def filter_invalid_values(element):
     and the record validators are defined in the `INVALID_GROUP_RULES_BY_MESSAGE_TYPE`
     dictionary.
 
-    Arguments:
-    `element`: The element to apply the field and record validators to.
+    Args:
+        element (dict): The element to apply the field and record validators to.
 
     Returns:
-    The element with the field and record validators applied.
+        dict: The element with the field and record validators applied.
     """
     element = apply_field_validators(element)
     element = apply_group_validators(element)

--- a/pipe_segment/transform/invalid_values.py
+++ b/pipe_segment/transform/invalid_values.py
@@ -1,4 +1,4 @@
-import decimal
+from decimal import Decimal
 
 
 def validate_field(is_invalid):
@@ -40,8 +40,8 @@ def float_to_fixed_point(value, precision):
         Decimal('120.0')
     """
     precision_format_string = "{{0:.{}f}}".format(precision)
-    precision_decimal = decimal.Decimal(precision_format_string.format(1))
-    return decimal.Decimal(value).quantize(precision_decimal)
+    precision_decimal = Decimal(precision_format_string.format(1))
+    return Decimal(value).quantize(precision_decimal)
 
 
 def validate_fixed_position_field(precision, is_invalid):

--- a/pipe_segment/transform/invalid_values.py
+++ b/pipe_segment/transform/invalid_values.py
@@ -216,6 +216,8 @@ def apply_field_validators(element):
     if field_validators is None:
         return element
 
+    # Making a copy of the element to avoid modifying the original
+    element = element.copy()
     for field, validator in field_validators.items():
         unfiltered_value = element.get(field)
         if unfiltered_value is not None:

--- a/pipe_segment/transform/invalid_values.py
+++ b/pipe_segment/transform/invalid_values.py
@@ -188,7 +188,7 @@ INVALID_RECORD_RULES_BY_MESSAGE_TYPE = {
         # VMS messages with both lat and lon set to 0 are invalid
         # and should be set to None
         "lat,lon": validate_all_fields_record(["lat", "lon"],
-                                              lambda x: float_to_fixed_point(x, 2) == 0),
+                                              lambda x: x == 0),
     }
 }
 

--- a/tests/transform/test_invalid_values.py
+++ b/tests/transform/test_invalid_values.py
@@ -1,4 +1,8 @@
-from pipe_segment.transform.invalid_values import filter_invalid_values
+from decimal import Decimal
+
+from pipe_segment.transform.invalid_values import (filter_invalid_values,
+                                                   float_to_fixed_point,
+                                                   validate_all_fields_record)
 
 
 class TestInvalidData:
@@ -940,8 +944,120 @@ class TestInvalidData:
 
         assert expected == actual
 
+    def test_vms_type_messages(self):
+        source = [
+            {
+                "type": "VMS",
+                "lat": -35,
+                "lon": -125,
+                "course": 112.35,
+                "speed": 35.45,
+            },
+            {"type": "VMS", "lat": -90, "lon": -180, "course": 0, "speed": 0},
+            {"type": "VMS", "lat": -91, "lon": -181, "course": -1, "speed": -1},
+            {"type": "VMS", "lat": 91, "lon": 181, "course": 360, "speed": 102.3},
+            {
+                "type": "VMS",
+                "lat": 90.997,
+                "lon": 180.996,
+                "course": 359.6,
+                "speed": 62.9,
+            },
+            {
+                "type": "VMS",
+                "lat": 90.001,
+                "lon": 180.001,
+                "course": 359.1,
+                "speed": 62.2999,
+            },
+            {"type": "VMS", "lat": None, "lon": None, "course": None, "speed": None},
+            {
+                "type": "VMS",
+                "lat": 0,
+                "lon": 0,
+                "course": 7,
+                "speed": 12,
+            },
+        ]
+
+        expected = [
+            {
+                "type": "VMS",
+                "lat": -35,
+                "lon": -125,
+                "course": 112.35,
+                "speed": 35.45,
+            },
+            {"type": "VMS", "lat": -90, "lon": -180, "course": 0, "speed": 0},
+            {"type": "VMS", "lat": None, "lon": None, "course": None, "speed": None},
+            {"type": "VMS", "lat": None, "lon": None, "course": None, "speed": 102.3},
+            {
+                "type": "VMS",
+                "lat": None,
+                "lon": None,
+                "course": 359.6,
+                "speed": 62.9,
+            },
+            {
+                "type": "VMS",
+                "lat": None,
+                "lon": None,
+                "course": 359.1,
+                "speed": 62.2999,
+            },
+            {"type": "VMS", "lat": None, "lon": None, "course": None, "speed": None},
+            {
+                "type": "VMS",
+                "lat": None,
+                "lon": None,
+                "course": 7,
+                "speed": 12,
+            },
+        ]
+
+        actual = [filter_invalid_values(x) for x in source]
+
+        assert actual == expected
+
 
 def test_no_validator():
     element = {"type": "DUMMY"}
 
     assert filter_invalid_values(element) == element
+
+
+def test_validate_all_fields_record():
+    expected = {
+        "lat": None,
+        "lon": None,
+    }
+    validator = validate_all_fields_record(["lat", "lon"], lambda x: x == 0)
+
+    assert validator({"lat": 0, "lon": 0}) == {"lat": None, "lon": None}
+    assert validator({"lat": 10, "lon": 0}) == {"lat": 10, "lon": 0}
+    assert validator({"lat": 0, "lon": 10}) == {"lat": 0, "lon": 10}
+    assert validator({"lat": None, "lon": 10}) == {"lat": None, "lon": 10}
+    assert validator({"lat": 10, "lon": None}) == {"lat": 10, "lon": None}
+    assert validator({"lat": None, "lon": None}) == {"lat": None, "lon": None}
+    assert validator({"lat": 0, "lon": 0, "course": 0}) == expected
+
+
+def test_float_to_fixed_point():
+    # Basic rounding
+    assert float_to_fixed_point(120.034, 1) == Decimal("120.0")
+    assert float_to_fixed_point(120.034, 2) == Decimal("120.03")
+    assert float_to_fixed_point(120.036, 2) == Decimal("120.04")
+    # No decimal places
+    assert float_to_fixed_point(123.99, 0) == Decimal("124")
+    assert float_to_fixed_point(123.01, 0) == Decimal("123")
+    # Negative numbers
+    assert float_to_fixed_point(-45.678, 1) == Decimal("-45.7")
+    assert float_to_fixed_point(-45.678, 2) == Decimal("-45.68")
+    # Zero
+    assert float_to_fixed_point(0, 2) == Decimal("0.00")
+    # Large precision
+    assert float_to_fixed_point(1.234567, 5) == Decimal("1.23457")
+    # Already a Decimal
+    assert float_to_fixed_point(Decimal("1.2345"), 3) == Decimal("1.234")
+    # Integer input
+    assert float_to_fixed_point(5, 2) == Decimal("5.00")

--- a/tests/transform/test_invalid_values.py
+++ b/tests/transform/test_invalid_values.py
@@ -945,79 +945,100 @@ class TestInvalidData:
         assert expected == actual
 
     def test_vms_type_messages(self):
-        source = [
-            {
-                "type": "VMS",
-                "lat": -35,
-                "lon": -125,
-                "course": 112.35,
-                "speed": 35.45,
-            },
-            {"type": "VMS", "lat": -90, "lon": -180, "course": 0, "speed": 0},
-            {"type": "VMS", "lat": -91, "lon": -181, "course": -1, "speed": -1},
-            {"type": "VMS", "lat": 91, "lon": 181, "course": 360, "speed": 102.3},
-            {
-                "type": "VMS",
-                "lat": 90.997,
-                "lon": 180.996,
-                "course": 359.6,
-                "speed": 62.9,
-            },
-            {
-                "type": "VMS",
-                "lat": 90.001,
-                "lon": 180.001,
-                "course": 359.1,
-                "speed": 62.2999,
-            },
-            {"type": "VMS", "lat": None, "lon": None, "course": None, "speed": None},
-            {
-                "type": "VMS",
-                "lat": 0,
-                "lon": 0,
-                "course": 7,
-                "speed": 12,
-            },
+        test_cases = [
+            (
+                "valid values",
+                {
+                    "type": "VMS",
+                    "lat": -35,
+                    "lon": -125,
+                    "course": 112.35,
+                    "speed": 35.45,
+                },
+                {
+                    "type": "VMS",
+                    "lat": -35,
+                    "lon": -125,
+                    "course": 112.35,
+                    "speed": 35.45,
+                },
+            ),
+            (
+                "boundary values",
+                {"type": "VMS", "lat": -90, "lon": -180, "course": 0, "speed": 0},
+                {"type": "VMS", "lat": -90, "lon": -180, "course": 0, "speed": 0},
+            ),
+            (
+                "invalid negative values",
+                {"type": "VMS", "lat": -91, "lon": -181, "course": -1, "speed": -1},
+                {"type": "VMS", "lat": None, "lon": None, "course": None, "speed": None},
+            ),
+            (
+                "invalid positive values",
+                {"type": "VMS", "lat": 91, "lon": 181, "course": 360, "speed": 102.3},
+                {"type": "VMS", "lat": None, "lon": None, "course": None, "speed": 102.3},
+            ),
+            (
+                "lat/lon out of bounds",
+                {
+                    "type": "VMS",
+                    "lat": 90.997,
+                    "lon": 180.996,
+                    "course": 359.6,
+                    "speed": 62.9,
+                },
+                {
+                    "type": "VMS",
+                    "lat": None,
+                    "lon": None,
+                    "course": 359.6,
+                    "speed": 62.9,
+                },
+            ),
+            (
+                "lat/lon slightly out of bounds",
+                {
+                    "type": "VMS",
+                    "lat": 90.001,
+                    "lon": 180.001,
+                    "course": 359.1,
+                    "speed": 62.2999,
+                },
+                {
+                    "type": "VMS",
+                    "lat": None,
+                    "lon": None,
+                    "course": 359.1,
+                    "speed": 62.2999,
+                },
+            ),
+            (
+                "all None",
+                {"type": "VMS", "lat": None, "lon": None, "course": None, "speed": None},
+                {"type": "VMS", "lat": None, "lon": None, "course": None, "speed": None},
+            ),
+            (
+                "zero lat/lon",
+                {
+                    "type": "VMS",
+                    "lat": 0,
+                    "lon": 0,
+                    "course": 7,
+                    "speed": 12,
+                },
+                {
+                    "type": "VMS",
+                    "lat": None,
+                    "lon": None,
+                    "course": 7,
+                    "speed": 12,
+                },
+            ),
         ]
 
-        expected = [
-            {
-                "type": "VMS",
-                "lat": -35,
-                "lon": -125,
-                "course": 112.35,
-                "speed": 35.45,
-            },
-            {"type": "VMS", "lat": -90, "lon": -180, "course": 0, "speed": 0},
-            {"type": "VMS", "lat": None, "lon": None, "course": None, "speed": None},
-            {"type": "VMS", "lat": None, "lon": None, "course": None, "speed": 102.3},
-            {
-                "type": "VMS",
-                "lat": None,
-                "lon": None,
-                "course": 359.6,
-                "speed": 62.9,
-            },
-            {
-                "type": "VMS",
-                "lat": None,
-                "lon": None,
-                "course": 359.1,
-                "speed": 62.2999,
-            },
-            {"type": "VMS", "lat": None, "lon": None, "course": None, "speed": None},
-            {
-                "type": "VMS",
-                "lat": None,
-                "lon": None,
-                "course": 7,
-                "speed": 12,
-            },
-        ]
-
-        actual = [filter_invalid_values(x) for x in source]
-
-        assert actual == expected
+        for label, source, expected in test_cases:
+            actual = filter_invalid_values(source)
+            assert actual == expected, f"Failed test case: {label}"
 
 
 def test_no_validator():

--- a/tests/transform/test_invalid_values.py
+++ b/tests/transform/test_invalid_values.py
@@ -1069,27 +1069,27 @@ def test_validate_all_fields_record():
         "lat": None,
         "lon": None,
     }
-    validator = validate_all_fields_record(["lat", "lon"], lambda x: x == 0)
+    validator = validate_all_fields_record(lambda x: x == 0)
 
-    assert validator({"lat": 0, "lon": 0}) == {"lat": None, "lon": None}, (
+    assert validator(("lat", "lon"), {"lat": 0, "lon": 0}) == {"lat": None, "lon": None}, (
         "Both lat and lon are zero"
     )
-    assert validator({"lat": 10, "lon": 0}) == {"lat": 10, "lon": 0}, (
+    assert validator(("lat", "lon"), {"lat": 10, "lon": 0}) == {"lat": 10, "lon": 0}, (
         "Only lon is zero"
     )
-    assert validator({"lat": 0, "lon": 10}) == {"lat": 0, "lon": 10}, (
+    assert validator(("lat", "lon"), {"lat": 0, "lon": 10}) == {"lat": 0, "lon": 10}, (
         "Only lat is zero"
     )
-    assert validator({"lat": None, "lon": 10}) == {"lat": None, "lon": 10}, (
+    assert validator(("lat", "lon"), {"lat": None, "lon": 10}) == {"lat": None, "lon": 10}, (
         "Lat is None"
     )
-    assert validator({"lat": 10, "lon": None}) == {"lat": 10, "lon": None}, (
+    assert validator(("lat", "lon"), {"lat": 10, "lon": None}) == {"lat": 10, "lon": None}, (
         "Lon is None"
     )
-    assert validator({"lat": None, "lon": None}) == {"lat": None, "lon": None}, (
+    assert validator(("lat", "lon"), {"lat": None, "lon": None}) == {"lat": None, "lon": None}, (
         "Both lat and lon are None"
     )
-    assert validator({"lat": 0, "lon": 0, "course": 0}) == expected, (
+    assert validator(("lat", "lon"), {"lat": 0, "lon": 0, "course": 0}) == expected, (
         "Extra field is removed from the result"
     )
 

--- a/tests/transform/test_invalid_values.py
+++ b/tests/transform/test_invalid_values.py
@@ -1034,6 +1034,23 @@ class TestInvalidData:
                     "speed": 12,
                 },
             ),
+            (
+                "zero lat/lon",
+                {
+                    "type": "VMS",
+                    "lat": 0.0001,
+                    "lon": 0.0001,
+                    "course": 7,
+                    "speed": 12,
+                },
+                {
+                    "type": "VMS",
+                    "lat": 0.0001,
+                    "lon": 0.0001,
+                    "course": 7,
+                    "speed": 12,
+                },
+            ),
         ]
 
         for label, source, expected in test_cases:
@@ -1054,13 +1071,27 @@ def test_validate_all_fields_record():
     }
     validator = validate_all_fields_record(["lat", "lon"], lambda x: x == 0)
 
-    assert validator({"lat": 0, "lon": 0}) == {"lat": None, "lon": None}
-    assert validator({"lat": 10, "lon": 0}) == {"lat": 10, "lon": 0}
-    assert validator({"lat": 0, "lon": 10}) == {"lat": 0, "lon": 10}
-    assert validator({"lat": None, "lon": 10}) == {"lat": None, "lon": 10}
-    assert validator({"lat": 10, "lon": None}) == {"lat": 10, "lon": None}
-    assert validator({"lat": None, "lon": None}) == {"lat": None, "lon": None}
-    assert validator({"lat": 0, "lon": 0, "course": 0}) == expected
+    assert validator({"lat": 0, "lon": 0}) == {"lat": None, "lon": None}, (
+        "Both lat and lon are zero"
+    )
+    assert validator({"lat": 10, "lon": 0}) == {"lat": 10, "lon": 0}, (
+        "Only lon is zero"
+    )
+    assert validator({"lat": 0, "lon": 10}) == {"lat": 0, "lon": 10}, (
+        "Only lat is zero"
+    )
+    assert validator({"lat": None, "lon": 10}) == {"lat": None, "lon": 10}, (
+        "Lat is None"
+    )
+    assert validator({"lat": 10, "lon": None}) == {"lat": 10, "lon": None}, (
+        "Lon is None"
+    )
+    assert validator({"lat": None, "lon": None}) == {"lat": None, "lon": None}, (
+        "Both lat and lon are None"
+    )
+    assert validator({"lat": 0, "lon": 0, "course": 0}) == expected, (
+        "Extra field is removed from the result"
+    )
 
 
 def test_float_to_fixed_point():


### PR DESCRIPTION
https://globalfishingwatch.atlassian.net/browse/PIPELINE-2664

This pull request introduces enhancements to the validation logic for handling invalid values in `pipe_segment/transform/invalid_values.py` and adds comprehensive test coverage in `tests/transform/test_invalid_values.py`. The changes include new validators for VMS message types, a utility function for validating multiple fields, and corresponding test cases to ensure correctness. Additionally, a minor update was made to the `compose.yaml` file to specify the platform for the BigQuery emulator.

### Validation Enhancements

* **New Record-Level Validation:**
  - Added `validate_all_fields_record` function to check if all specified fields in a record are invalid and set them to `None` if so.
  - Introduced `INVALID_RECORD_RULES_BY_MESSAGE_TYPE` for defining record-level validation rules, such as marking VMS messages with `lat` and `lon` both set to 0 as invalid.

* **Field-Level Validation Updates:**
  - Added new field validators for VMS message types to validate `lat`, `lon`, `course`, and `speed` fields.

* **Unified Validation Pipeline:**
  - Refactored `filter_invalid_values` to apply both field-level and record-level validators using `apply_field_validators` and `apply_record_validators`.

### Test Suite Enhancements

* **Expanded Test Cases:**
  - Added test cases for VMS message validation, covering various scenarios like valid values, boundary values, and invalid values for `lat` and `lon`.
  - Added unit tests for `validate_all_fields_record` and `float_to_fixed_point` functions to ensure correctness.

### Configuration Update

* **Compose File Update:**
  - Specified `platform: linux/x86_64` for the BigQuery emulator service in `compose.yaml` to ensure compatibility with osx.