### PR TITLE
PIPELINE-2685: Broken dataflow docker image

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,6 +6,8 @@ steps:
     '-t', '${_IMAGE_NAME}:${TAG_NAME}',
     '-t', '${_IMAGE_NAME}:latest',
     '-f', 'Dockerfile',
+    '--target',
+    "prod",
     '.',
   ]
 


### PR DESCRIPTION
See https://globalfishingwatch.atlassian.net/browse/PIPELINE-2685

The default image is using the dev target instead of prod, which means the image is no longer a valid beam worker image.