### PR TITLE
ENG-827: Adds billing project id parameter to bash queries

### DIFF
--- a/scripts/segment_info.sh
+++ b/scripts/segment_info.sh
@@ -16,6 +16,13 @@ ARGS=( \
 )
 TABLE_ARGS=("SEGMENT_IDENTITY_TABLE" "SEGMENT_VESSEL_DAILY" "DEST_TABLE")
 
+################################################################################
+# Setup up project to be billed for this process
+################################################################################
+if [ -z "${BILLING_PROJECT_ID}" ]; then
+  BILLING_PROJECT_ID=world-fishing-827
+fi
+echo "Using billing project id ${BILLING_PROJECT_ID}"
 
 ################################################################################
 # Validate and extract arguments
@@ -90,7 +97,7 @@ jinja2 ${SQL} \
    -D most_common_min_freq=${MOST_COMMON_MIN_FREQ} \
    | bq query --headless --max_rows=0 --allow_large_results --replace \
      ${LABELS_PARAM} --destination_table ${DEST_TABLE} \
-     --destination_schema ${SCHEMA}
+     --destination_schema ${SCHEMA} --project_id ${BILLING_PROJECT_ID}
 
 if [ "$?" -ne 0 ]; then
   echo "  Unable to insert records for table ${DEST_TABLE}"

--- a/scripts/segment_vessel.sh
+++ b/scripts/segment_vessel.sh
@@ -15,6 +15,14 @@ ARGS=( \
 TABLE_ARGS=("SEGMENT_VESSEL_TABLE" "DEST_TABLE")
 
 ################################################################################
+# Setup up project to be billed for this process
+################################################################################
+if [ -z "${BILLING_PROJECT_ID}" ]; then
+  BILLING_PROJECT_ID=world-fishing-827
+fi
+echo "Using billing project id ${BILLING_PROJECT_ID}"
+
+################################################################################
 # Validate and extract arguments
 ################################################################################
 display_usage() {
@@ -80,7 +88,7 @@ echo "Publishing ${PROCESS} to ${DEST_TABLE}..."
 jinja2 ${SQL} \
    -D segment_vessel_daily=${SEGMENT_VESSEL_TABLE//:/.} \
    | bq query --headless --max_rows=0 --allow_large_results --replace \
-     ${LABELS_PARAM} --destination_table ${DEST_TABLE}
+     ${LABELS_PARAM} --destination_table ${DEST_TABLE} --project_id ${BILLING_PROJECT_ID}
 
 if [ "$?" -ne 0 ]; then
   echo "  Unable to insert records for table ${DEST_TABLE}"

--- a/scripts/segment_vessel_daily.sh
+++ b/scripts/segment_vessel_daily.sh
@@ -20,6 +20,14 @@ ARGS=( \
 TABLE_ARGS=("SEGMENT_IDENTITY_TABLE" "DEST_TABLE")
 
 ################################################################################
+# Setup up project to be billed for this process
+################################################################################
+if [ -z "${BILLING_PROJECT_ID}" ]; then
+  BILLING_PROJECT_ID=world-fishing-827
+fi
+echo "Using billing project id ${BILLING_PROJECT_ID}"
+
+################################################################################
 # Validate and extract arguments
 ################################################################################
 display_usage() {
@@ -93,7 +101,7 @@ jinja2 ${SQL} \
    -D spoofing_threshold=${SPOOFING_THRESHOLD} \
    -D segment_identity_daily=${SEGMENT_IDENTITY_TABLE//:/.} \
    | bq query --headless --max_rows=0 --allow_large_results --replace \
-     ${LABELS_PARAM} --destination_table ${DEST_TABLE}
+     ${LABELS_PARAM} --destination_table ${DEST_TABLE} --project_id ${BILLING_PROJECT_ID}
 
 if [ "$?" -ne 0 ]; then
   echo "  Unable to insert records for table ${DEST_TABLE}"

--- a/scripts/vessel_info.sh
+++ b/scripts/vessel_info.sh
@@ -17,6 +17,14 @@ ARGS=( \
 TABLE_ARGS=("SEGMENT_IDENTITY_TABLE" "SEGMENT_VESSEL_TABLE" "DEST_TABLE")
 
 ################################################################################
+# Setup up project to be billed for this process
+################################################################################
+if [ -z "${BILLING_PROJECT_ID}" ]; then
+  BILLING_PROJECT_ID=world-fishing-827
+fi
+echo "Using billing project id ${BILLING_PROJECT_ID}"
+
+################################################################################
 # Validate and extract arguments
 ################################################################################
 display_usage() {
@@ -88,7 +96,7 @@ jinja2 ${SQL} \
    -D most_common_min_freq=${MOST_COMMON_MIN_FREQ} \
    | bq query --headless --max_rows=0 --allow_large_results --replace \
      ${LABELS_PARAM} --destination_table ${DEST_TABLE} \
-     --destination_schema ${SCHEMA}
+     --destination_schema ${SCHEMA} --project_id ${BILLING_PROJECT_ID}
 
 if [ "$?" -ne 0 ]; then
   echo "  Unable to insert records for table ${DEST_TABLE}"


### PR DESCRIPTION
We need this to ensure proper execution on the infrastructure project as project id is no longer optional for bash steps. To be clear, @smpiano is working on a better approach making project mandatory and migrating those bash scripts to python, but until we can deploy that we can use this change as it is backwards compatible.

This can be used by setting up `env_vars` in a `KubernetesPodOperator` for instance. If you don't set it up (ie: in the current pipeline configs) it defaults to wf827. See https://github.com/GlobalFishingWatch/composer-dags-production/blob/gcp-migration/gfw/pipes/v3/segment.py#L198 for an example.